### PR TITLE
Fix status response reading logic

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -163,6 +163,8 @@ where
 		let stuffed_message_len = loop {
 			self.remove_garbage();
 
+			// The call to remove_garbage() removes all leading bytes that don't match a status header.
+			// So if there's enough bytes left, it's a status header.
 			if self.read_len > STATUS_HEADER_SIZE {
 				let read_buffer = &self.read_buffer.as_mut()[..self.read_len];
 				let body_len = read_buffer[5] as usize + read_buffer[6] as usize * 256;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -161,17 +161,15 @@ where
 	pub fn read_status_response(&mut self) -> Result<Response<ReadBuffer, WriteBuffer>, ReadError> {
 		let deadline = Instant::now() + self.read_timeout;
 		let stuffed_message_len = loop {
-			if self.read_len > HEADER_PREFIX.len() {
-				self.remove_garbage();
+			self.remove_garbage();
 
-				if self.read_len > STATUS_HEADER_SIZE && self.read_buffer.as_mut()[..self.read_len].starts_with(&HEADER_PREFIX) {
-					let read_buffer = &self.read_buffer.as_mut()[..self.read_len];
-					let body_len = read_buffer[5] as usize + read_buffer[6] as usize * 256;
-					let body_len = body_len - 2; // Length includes instruction and error fields, which is already included in STATUS_HEADER_SIZE too.
+			if self.read_len > STATUS_HEADER_SIZE {
+				let read_buffer = &self.read_buffer.as_mut()[..self.read_len];
+				let body_len = read_buffer[5] as usize + read_buffer[6] as usize * 256;
+				let body_len = body_len - 2; // Length includes instruction and error fields, which is already included in STATUS_HEADER_SIZE too.
 
-					if self.read_len >= STATUS_HEADER_SIZE + body_len {
-						break STATUS_HEADER_SIZE + body_len;
-					}
+				if self.read_len >= STATUS_HEADER_SIZE + body_len {
+					break STATUS_HEADER_SIZE + body_len;
 				}
 			}
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -161,6 +161,20 @@ where
 	pub fn read_status_response(&mut self) -> Result<Response<ReadBuffer, WriteBuffer>, ReadError> {
 		let deadline = Instant::now() + self.read_timeout;
 		let stuffed_message_len = loop {
+			if self.read_len > HEADER_PREFIX.len() {
+				self.remove_garbage();
+
+				if self.read_len > STATUS_HEADER_SIZE && self.read_buffer.as_mut()[..self.read_len].starts_with(&HEADER_PREFIX) {
+					let read_buffer = &self.read_buffer.as_mut()[..self.read_len];
+					let body_len = read_buffer[5] as usize + read_buffer[6] as usize * 256;
+					let body_len = body_len - 2; // Length includes instruction and error fields, which is already included in STATUS_HEADER_SIZE too.
+
+					if self.read_len >= STATUS_HEADER_SIZE + body_len {
+						break STATUS_HEADER_SIZE + body_len;
+					}
+				}
+			}
+
 			if Instant::now() > deadline {
 				trace!("timeout reading status response, data in buffer: {:02X?}", &self.read_buffer.as_ref()[..self.read_len]);
 				return Err(std::io::ErrorKind::TimedOut.into());
@@ -173,23 +187,6 @@ where
 			}
 
 			self.read_len += new_data;
-			self.remove_garbage();
-
-			let read_buffer = &self.read_buffer.as_mut()[..self.read_len];
-			if !read_buffer.starts_with(&HEADER_PREFIX) {
-				continue;
-			}
-
-			if self.read_len < STATUS_HEADER_SIZE {
-				continue;
-			}
-
-			let body_len = read_buffer[5] as usize + read_buffer[6] as usize * 256;
-			let body_len = body_len - 2; // Length includes instruction and error fields, which is already included in STATUS_HEADER_SIZE too.
-
-			if self.read_len >= STATUS_HEADER_SIZE + body_len {
-				break STATUS_HEADER_SIZE + body_len;
-			}
 		};
 
 		let buffer = self.read_buffer.as_mut();


### PR DESCRIPTION
Currently when ```read_status_response``` is called from ```sync_read_cb``` multiple packets can be read into the buffer but only one packet is parsed. This leads to the second response packet to be consumed without being parsed.

A sync read instruction packet is sent to 2 dynamixels, ID 1 and 2
```
Trace: sending instruction: [FF, FF, FD, 00, FE, 09, 00, 82, 7E, 00, 0A, 00, 02, 01, 32, 98]
```
The expected response data is read into the buffer on the first call to ```read_status_response```. Note that 2 packets are read, not one.
```
Trace: read data length: 42
Trace: read data: [FF, FF, FD, 00, 02, 0E, 00, 55, 00, 00, 00, 00, 00, 00, 00, C2, 09, 00, 00, 03, DB, FF, FF, FD, 00, 01, 0E, 00, 55, 00, 00, 00, 00, 00, 00, 00, 9F, 0C, 00, 00, 55, 7C] 
```
however the current implementation doesn't check if more than one packet was read so it timeouts trying to read a response it has already read.
```
Trace: read packet: [FF, FF, FD, 00, 02, 0E, 00, 55, 00, 00, 00, 00, 00, 00, 00, C2, 09, 00, 00, 03, DB]
Error: std::io::ErrorKind::TimedOut as serial port didn't receive any more data
```

Moving the read buffer checks, that check if the read buffer has a valid packet, to before the ```self.serial_port.read``` call prevents this issue. Although the nested if statements may not be the most elegant solution.