### PR TITLE
Return hardware errors with register data

### DIFF
--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,0 +1,30 @@
+// mod _logging;
+use dynamixel2::{Bus, MotorError, ReadError, TransferError};
+use std::path::PathBuf;
+
+const PRESENT_POSITION: (u16, u16) = (132, 4);
+
+fn main() {
+	let serial_port: PathBuf = "/dev/ttyUSB0".into();
+	// _logging::init(env!("CARGO_CRATE_NAME"), 3);
+	let mut bus = Bus::open_with_buffers(
+		&serial_port,
+		4000000,
+		std::time::Duration::from_millis(20),
+		vec![0; 1024],
+		vec![0; 1024],
+	)
+	.map_err(|e| println!("Failed to open serial port: {}: {}", serial_port.display(), e))
+	.unwrap();
+
+	let response: Result<u32, TransferError<u32>> = bus.read_u32(37, PRESENT_POSITION.0);
+	let present_position = match response {
+		Err(TransferError::ReadError(ReadError::MotorError(MotorError::HardwareError(data)))) => {
+			println!("Motor has hardware Error");
+			data
+		},
+		Err(e) => panic!("Error: {:?}", e),
+		Ok(data) => data,
+	};
+	println!("Present Position: {}", present_position)
+}

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -1,33 +1,6 @@
 use super::instruction_id;
-use crate::endian::{read_u8_le, read_u16_le, read_u32_le, write_u16_le};
-use crate::{Bus, TransferError};
-
-pub struct ReadResponse<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	pub(crate) response: crate::Response<'a, ReadBuffer, WriteBuffer>,
-}
-
-impl<'a, ReadBuffer, WriteBuffer> ReadResponse<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	/// Get the ID of the motor.
-	pub fn motor_id(&self) -> u8 {
-		self.response.packet_id()
-	}
-
-	/// Get the read data as byte slice.
-	///
-	/// The individual registers of the motor are encoded as little-endian.
-	/// Refer to the online manual of your motor for the addresses and sizes of all registers.
-	pub fn data(&self) -> &[u8] {
-		self.response.parameters()
-	}
-}
+use crate::endian::{read_u16_le, read_u32_le, read_u8_le, write_u16_le};
+use crate::{Bus, Response, TransferError};
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
 where
@@ -38,21 +11,27 @@ where
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<ReadResponse<ReadBuffer, WriteBuffer>, TransferError> {
+	pub fn read(
+		&mut self,
+		motor_id: u8,
+		address: u16,
+		count: u16,
+	) -> Result<Response<ReadBuffer, WriteBuffer>, TransferError<Response<ReadBuffer, WriteBuffer>>> {
 		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), count.into()).map_err(crate::ReadError::from)?;
-		Ok(ReadResponse { response })
+		Ok(response)
 	}
 
 	/// Read an 8 bit register from a specific motor.
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<u8, TransferError> {
-		let response = self.read(motor_id, address, 1)?;
+	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<u8, TransferError<u8>> {
+		let response = self.read(motor_id, address, 1);
+		let response = response?;
 		Ok(read_u8_le(response.data()))
 	}
 
@@ -60,7 +39,7 @@ where
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<u16, TransferError> {
+	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<u16, TransferError<u16>> {
 		let response = self.read(motor_id, address, 2)?;
 		Ok(read_u16_le(response.data()))
 	}
@@ -69,7 +48,7 @@ where
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<u32, TransferError> {
+	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<u32, TransferError<u32>> {
 		let response = self.read(motor_id, address, 4)?;
 		Ok(read_u32_le(response.data()))
 	}


### PR DESCRIPTION
A proof of concept that, whilst it does work, contains a lot of generic types in the error enums and is not very pretty.