### PR TITLE
changed functions to return a response struct,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+main:
+  * Fix amount of data read in `sync_read_u16` and `sync_read_u16_cb`.
+
 v0.5.0 - 2023-12-02:
   * Update `serial2` to `v0.2`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ main:
   * Fix amount of data read in `sync_read_u16` and `sync_read_u16_cb`.
   * Do not return `Err()` when the `alert` bit is set in a status packet from a motor.
   * Report the `alert` bit in the returned values from commands in a new `Response` struct.
+  * Pass original `BulkReadData` command to user callback in `bulk_read_cb()`.
 
 v0.5.1 - 2023-12-07:
   * Parse all status messages when more than on has been read in a single `read()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 main:
   * Fix amount of data read in `sync_read_u16` and `sync_read_u16_cb`.
+  * Do not return `Err()` when the `alert` bit is set in a status packet from a motor.
+  * Report the `alert` bit in the returned values from commands in a new `Response` struct.
 
 v0.5.1 - 2023-12-07:
   * Parse all status messages when more than on has been read in a single `read()`.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -316,7 +316,6 @@ pub struct Response<T> {
 	pub motor_id: u8,
 	pub alert: bool,
 	pub data: T,
-	pub address: Option<u16>,
 }
 
 impl<'a, ReadBuffer, WriteBuffer> From<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<()>
@@ -329,7 +328,6 @@ where
 			data: (),
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
-			address: None,
 		}
 	}
 }
@@ -344,7 +342,6 @@ where
 			data: status_packet.parameters().to_owned(),
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
-			address: None,
 		}
 	}
 }
@@ -359,7 +356,6 @@ where
 			data: read_u8_le(status_packet.parameters()),
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
-			address: None,
 		}
 	}
 }
@@ -374,7 +370,6 @@ where
 			data: read_u16_le(status_packet.parameters()),
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
-			address: None,
 		}
 	}
 }
@@ -389,7 +384,6 @@ where
 			data: read_u32_le(status_packet.parameters()),
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
-			address: None,
 		}
 	}
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -311,6 +311,7 @@ where
 	}
 }
 
+#[derive(Debug)]
 pub struct Response<T> {
 	pub motor_id: u8,
 	pub alert: bool,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -208,7 +208,7 @@ where
 		// Remove byte-stuffing from the parameters.
 		let parameter_count = bytestuff::unstuff_inplace(&mut buffer[STATUS_HEADER_SIZE..parameters_end]);
 
-		// Creating the response struct here means that the data gets purged from the buffer even if we return early using the try operator.
+		// Creating the status packet struct here means that the data gets purged from the buffer even if we return early using the try operator.
 		let response = StatusPacket {
 			bus: self,
 			stuffed_message_len,
@@ -290,7 +290,7 @@ where
 		self.as_bytes()[8]
 	}
 
-	// The alert bit from the error feild of the response.
+	// The alert bit from the error field of the response.
 	pub fn alert(&self) -> bool {
 		self.error() & 0x80 != 0
 	}
@@ -311,10 +311,19 @@ where
 	}
 }
 
+/// A response from a motor.
 #[derive(Debug)]
 pub struct Response<T> {
+	/// The motor that sent the response.
 	pub motor_id: u8,
+
+	/// The alert bit from the response message.
+	///
+	/// If this is set, you can normally check the "Hardware Error" register for more details.
+	/// Consult your motor manual for more details.
 	pub alert: bool,
+
+	/// The data from the motor.
 	pub data: T,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -183,6 +183,42 @@ impl From<ReadError> for TransferError {
 	}
 }
 
+impl From<InvalidMessage> for TransferError {
+	fn from(other: InvalidMessage) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
+impl From<InvalidHeaderPrefix> for TransferError {
+	fn from(other: InvalidHeaderPrefix) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
+impl From<InvalidChecksum> for TransferError {
+	fn from(other: InvalidChecksum) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
+impl From<InvalidPacketId> for TransferError {
+	fn from(other: InvalidPacketId) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
+impl From<InvalidInstruction> for TransferError {
+	fn from(other: InvalidInstruction) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
+impl From<InvalidParameterCount> for TransferError {
+	fn from(other: InvalidParameterCount) -> Self {
+		Self::ReadError(other.into())
+	}
+}
+
 impl From<std::io::Error> for ReadError {
 	fn from(other: std::io::Error) -> Self {
 		Self::Io(other)

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,7 +82,7 @@ pub struct InvalidParameterCount {
 
 impl MotorError {
 	pub fn check(raw: u8) -> Result<(), Self> {
-		if raw == 0 {
+		if raw & !0x80 == 0 {
 			Ok(())
 		} else {
 			Err(Self { raw })

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,8 @@ pub struct InvalidParameterCount {
 
 impl MotorError {
 	pub fn check(raw: u8) -> Result<(), Self> {
+		// Ignore the alert bit for this check.
+		// If the alert bit is set, the motor encountered an error, but the instruction was still executed.
 		if raw & !0x80 == 0 {
 			Ok(())
 		} else {

--- a/src/instructions/action.rs
+++ b/src/instructions/action.rs
@@ -12,8 +12,7 @@ where
 	/// Instead use [`Self::broadcast_action`].
 	pub fn action(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::ACTION, 0, |_| ())?;
-		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Broadcast an action command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/action.rs
+++ b/src/instructions/action.rs
@@ -8,17 +8,12 @@ where
 {
 	/// Send an action command to trigger a previously registered instruction.
 	///
-	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
-	/// although the [`Self::broadcast_action`] is generally easier to use.
-	pub fn action(&mut self, motor_id: u8) -> Result<Option<Response<()>>, TransferError> {
-		if motor_id == packet_id::BROADCAST {
-			self.broadcast_action()?;
-			Ok(None)
-		} else {
-			let response = self.transfer_single(motor_id, instruction_id::ACTION, 0, |_| ())?;
-			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-			Ok(Some(response.into()))
-		}
+	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
+	/// Instead use [`Self::broadcast_action`].
+	pub fn action(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
+		let response = self.transfer_single(motor_id, instruction_id::ACTION, 0, |_| ())?;
+		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+		Ok(response.into())
 	}
 
 	/// Broadcast an action command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/action.rs
+++ b/src/instructions/action.rs
@@ -1,5 +1,5 @@
 use super::{instruction_id, packet_id};
-use crate::{Bus, TransferError, WriteError};
+use crate::{Bus, Response, TransferError, WriteError};
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
 where
@@ -10,14 +10,15 @@ where
 	///
 	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
 	/// although the [`Self::broadcast_action`] is generally easier to use.
-	pub fn action(&mut self, motor_id: u8) -> Result<(), TransferError> {
+	pub fn action(&mut self, motor_id: u8) -> Result<Option<Response<()>>, TransferError> {
 		if motor_id == packet_id::BROADCAST {
 			self.broadcast_action()?;
+			Ok(None)
 		} else {
 			let response = self.transfer_single(motor_id, instruction_id::ACTION, 0, |_| ())?;
 			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+			Ok(Some(response.into()))
 		}
-		Ok(())
 	}
 
 	/// Broadcast an action command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -22,7 +22,7 @@ where
 	pub fn bulk_read_cb<Read, F>(&mut self, reads: &[Read], mut on_response: F) -> Result<(), WriteError>
 	where
 		Read: AsRef<BulkReadData>,
-		F: FnMut(Result<Response<Vec<u8>>, ReadError>),
+		F: FnMut(&BulkReadData, Result<Response<Vec<u8>>, ReadError>),
 	{
 		for i in 0..reads.len() {
 			for j in i + 1..reads.len() {
@@ -55,8 +55,8 @@ where
 			});
 
 			match response {
-				Ok(response) => on_response(Ok(response.into())),
-				Err(e) => on_response(Err(e)),
+				Ok(response) => on_response(read, Ok(response.into())),
+				Err(e) => on_response(read, Err(e)),
 			}
 		}
 		Ok(())
@@ -79,7 +79,7 @@ where
 		let mut responses = Vec::with_capacity(reads.len());
 		let mut read_error = None;
 
-		self.bulk_read_cb(reads, |data| {
+		self.bulk_read_cb(reads, |_read, data| {
 			if read_error.is_none() {
 				match data {
 					Err(e) => read_error = Some(e),

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -1,6 +1,6 @@
-use super::{instruction_id, packet_id, BulkData};
-use crate::endian::{write_u8_le, write_u16_le};
-use crate::{Bus, ReadError, WriteError, TransferError};
+use super::{instruction_id, packet_id};
+use crate::endian::{write_u16_le, write_u8_le};
+use crate::{Bus, ReadError, Response, TransferError, WriteError};
 
 pub struct BulkRead {
 	pub motor_id: u8,
@@ -31,19 +31,20 @@ where
 	/// # Panics
 	/// The protocol forbids specifying the same motor ID multiple times.
 	/// This function panics if the same motor ID is used for more than one read.
-	pub fn bulk_read_cb<Read, F>(
-		&mut self,
-		reads: &[Read],
-		mut on_response: F,
-	) -> Result<(), WriteError>
+	pub fn bulk_read_cb<Read, F>(&mut self, reads: &[Read], mut on_response: F) -> Result<(), WriteError>
 	where
 		Read: AsRef<BulkRead>,
-		F: FnMut(Result<BulkData<&[u8]>, ReadError>),
+		F: FnMut(Result<Response<Vec<u8>>, ReadError>),
 	{
 		for i in 0..reads.len() {
 			for j in i + 1..reads.len() {
 				if reads[i].as_ref().motor_id == reads[j].as_ref().motor_id {
-					panic!("bulk_read_cb: motor ID {} used multiple at index {} and {}", reads[i].as_ref().motor_id, i, j)
+					panic!(
+						"bulk_read_cb: motor ID {} used multiple at index {} and {}",
+						reads[i].as_ref().motor_id,
+						i,
+						j
+					)
 				}
 			}
 		}
@@ -66,10 +67,10 @@ where
 			});
 
 			match response {
-				Ok(response) => on_response(Ok(BulkData {
-					motor_id: read.motor_id,
-					address: read.address,
-					data: response.parameters(),
+				Ok(response) => on_response(Ok({
+					let mut response: Response<Vec<u8>> = response.into();
+					response.address = Some(read.address);
+					response
 				})),
 				Err(e) => on_response(Err(e)),
 			}
@@ -87,25 +88,18 @@ where
 	/// # Panics
 	/// The protocol forbids specifying the same motor ID multiple times.
 	/// This function panics if the same motor ID is used for more than one read.
-	pub fn bulk_read<Read>(
-		&mut self,
-		reads: &[Read],
-	) -> Result<Vec<BulkData<Vec<u8>>>, TransferError>
+	pub fn bulk_read<Read>(&mut self, reads: &[Read]) -> Result<Vec<Response<Vec<u8>>>, TransferError>
 	where
 		Read: AsRef<BulkRead>,
 	{
 		let mut responses = Vec::with_capacity(reads.len());
 		let mut read_error = None;
 
-		self.bulk_read_cb(reads, |bulk_data| {
+		self.bulk_read_cb(reads, |data| {
 			if read_error.is_none() {
-				match bulk_data {
+				match data {
 					Err(e) => read_error = Some(e),
-					Ok(bulk_data) => responses.push(BulkData {
-						motor_id: bulk_data.motor_id,
-						address: bulk_data.address,
-						data: bulk_data.data.to_owned(),
-					}),
+					Ok(data) => responses.push(data),
 				}
 			}
 		})?;

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -1,5 +1,5 @@
-use super::{instruction_id, packet_id, BulkData};
-use crate::endian::{write_u8_le, write_u16_le};
+use super::{instruction_id, packet_id, BulkWriteData};
+use crate::endian::{write_u16_le, write_u8_le};
 use crate::{Bus, WriteError};
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
@@ -22,7 +22,7 @@ where
 	/// This function also panics if the data length for a motor exceeds the capacity of a `u16`.
 	pub fn bulk_write<Write, T>(&mut self, writes: &[Write]) -> Result<(), WriteError>
 	where
-		Write: std::borrow::Borrow<BulkData<T>>,
+		Write: std::borrow::Borrow<BulkWriteData<T>>,
 		T: AsRef<[u8]>,
 	{
 		let mut parameter_count = 0;
@@ -30,7 +30,12 @@ where
 			let write = write.borrow();
 			let data = write.data.as_ref();
 			if data.len() > u16::MAX.into() {
-				panic!("bulk_write: data length ({}) for motor {} exceeds maximum size of {}", data.len(), write.motor_id, u16::MAX);
+				panic!(
+					"bulk_write: data length ({}) for motor {} exceeds maximum size of {}",
+					data.len(),
+					write.motor_id,
+					u16::MAX
+				);
 			}
 			parameter_count += 5 + data.len();
 		}

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -1,5 +1,5 @@
 use super::{instruction_id, packet_id};
-use crate::Bus;
+use crate::{Bus, Response};
 
 /// The parameters for the CLEAR command to clear the revolution counter.
 const CLEAR_REVOLUTION_COUNT: [u8; 5] = [0x01, 0x44, 0x58, 0x4C, 0x22];
@@ -17,14 +17,15 @@ where
 	///
 	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
 	/// although the [`Self::broadcast_clear_revolution_counter`] is generally easier to use.
-	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<(), crate::TransferError> {
+	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Option<Response<()>>, crate::TransferError> {
 		if motor_id == packet_id::BROADCAST {
 			self.broadcast_clear_revolution_counter()?;
+			Ok(None)
 		} else {
 			let response = self.transfer_single(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
 			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+			Ok(Some(response.into()))
 		}
-		Ok(())
 	}
 
 	/// Clear the revolution counter of all connected motors.

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -19,8 +19,7 @@ where
 	/// Instead use [`Self::broadcast_clear_revolution_counter`].
 	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Response<()>, crate::TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
-		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Clear the revolution counter of all connected motors.

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -15,17 +15,12 @@ where
 	/// It is not possible to clear the revolution counter of a motor while it is moving.
 	/// Doing so will cause the motor to return an error, and the revolution counter will not be reset.
 	///
-	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
-	/// although the [`Self::broadcast_clear_revolution_counter`] is generally easier to use.
-	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Option<Response<()>>, crate::TransferError> {
-		if motor_id == packet_id::BROADCAST {
-			self.broadcast_clear_revolution_counter()?;
-			Ok(None)
-		} else {
-			let response = self.transfer_single(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
-			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-			Ok(Some(response.into()))
-		}
+	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
+	/// Instead use [`Self::broadcast_clear_revolution_counter`].
+	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Response<()>, crate::TransferError> {
+		let response = self.transfer_single(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
+		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+		Ok(response.into())
 	}
 
 	/// Clear the revolution counter of all connected motors.

--- a/src/instructions/factory_reset.rs
+++ b/src/instructions/factory_reset.rs
@@ -36,8 +36,7 @@ where
 	/// Or use the ID Inspection Tool in the Dynamixel Wizard 2.0
 	pub fn factory_reset(&mut self, motor_id: u8, kind: FactoryResetKind) -> Result<Response<()>, crate::TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::FACTORY_RESET, 1, |buffer| buffer[0] = kind as u8)?;
-		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Reset the settings of all connected motors to the factory defaults.

--- a/src/instructions/factory_reset.rs
+++ b/src/instructions/factory_reset.rs
@@ -24,8 +24,8 @@ where
 	/// This will reset all registers to the factory default, including the EEPROM registers.
 	/// The only exceptions are the ID and baud rate settings, which may be kept depending on the `kind` argument.
 	///
-	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
-	/// although the [`Self::broadcast_factory_reset`] is generally easier to use.
+	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
+	/// Instead use [`Self::broadcast_factory_reset`].
 	///
 	/// Starting with version 42 of the firmware for the MX-series and X-series,
 	/// motors ignore a broadcast reset command with `FactoryResetKind::ResetAll`.
@@ -33,15 +33,11 @@ where
 	/// which would cause multiple motors on the bus to have the same ID.
 	/// At that point, communication with those motors is not possible anymore.
 	/// The only way to restore communication is to physically disconnect all but one motor at a time and re-assign unique IDs.
-	pub fn factory_reset(&mut self, motor_id: u8, kind: FactoryResetKind) -> Result<Option<Response<()>>, crate::TransferError> {
-		if motor_id == packet_id::BROADCAST {
-			self.broadcast_factory_reset(kind)?;
-			Ok(None)
-		} else {
-			let response = self.transfer_single(motor_id, instruction_id::FACTORY_RESET, 1, |buffer| buffer[0] = kind as u8)?;
-			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-			Ok(Some(response.into()))
-		}
+	/// Or use the ID Inspection Tool in the Dynamixel Wizard 2.0
+	pub fn factory_reset(&mut self, motor_id: u8, kind: FactoryResetKind) -> Result<Response<()>, crate::TransferError> {
+		let response = self.transfer_single(motor_id, instruction_id::FACTORY_RESET, 1, |buffer| buffer[0] = kind as u8)?;
+		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+		Ok(response.into())
 	}
 
 	/// Reset the settings of all connected motors to the factory defaults.

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -35,20 +35,18 @@ mod write;
 pub use factory_reset::FactoryResetKind;
 pub use ping::PingResponse;
 
-use crate::Response;
-
 /// Data from or for a specific motor.
 ///
-/// Used by synchronous read and write commands.
-pub struct SyncData<T> {
+/// Used by synchronous write commands.
+pub struct SyncWriteData<T> {
 	/// The ID of the motor.
 	pub motor_id: u8,
 
-	/// The data read from or to be written to the motor.
+	/// The data to be written to the motor.
 	pub data: T,
 }
 
-impl<T> AsRef<SyncData<T>> for SyncData<T> {
+impl<T> AsRef<SyncWriteData<T>> for SyncWriteData<T> {
 	fn as_ref(&self) -> &Self {
 		self
 	}
@@ -60,8 +58,8 @@ impl<T> AsRef<SyncData<T>> for SyncData<T> {
 /// but it supports reads and writes
 /// of different sizes and to different addresses for each motor.
 ///
-/// Used by bulk read and write commands.
-pub struct BulkData<T> {
+/// Used by bulk write commands.
+pub struct BulkWriteData<T> {
 	/// The ID of the motor.
 	pub motor_id: u8,
 
@@ -72,18 +70,25 @@ pub struct BulkData<T> {
 	pub data: T,
 }
 
-impl<T> AsRef<BulkData<T>> for BulkData<T> {
+impl<T> AsRef<BulkWriteData<T>> for BulkWriteData<T> {
 	fn as_ref(&self) -> &Self {
 		self
 	}
 }
 
-/// The data response giving by a motor in response to a bulk read command.
-#[derive(Debug)]
-pub struct BulkResponse<T> {
-	/// The response message.
-	pub response: Response<T>,
-	
-	/// The address of the bulk read/write.
+pub struct BulkReadData {
+	/// The ID of the motor.
+	pub motor_id: u8,
+
+	/// The address for the read or write.
 	pub address: u16,
+
+	// The length of the data to be read.
+	pub count: u16,
+}
+
+impl AsRef<BulkReadData> for BulkReadData {
+	fn as_ref(&self) -> &Self {
+		self
+	}
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -34,7 +34,6 @@ mod write;
 
 pub use factory_reset::FactoryResetKind;
 pub use ping::PingResponse;
-pub use read::ReadResponse;
 
 /// Data from or for a specific motor.
 ///

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -35,6 +35,8 @@ mod write;
 pub use factory_reset::FactoryResetKind;
 pub use ping::PingResponse;
 
+use crate::Response;
+
 /// Data from or for a specific motor.
 ///
 /// Used by synchronous read and write commands.
@@ -52,7 +54,7 @@ impl<T> AsRef<SyncData<T>> for SyncData<T> {
 	}
 }
 
-/// Bulk data from or for a specific motor.
+/// Bulk data for a specific motor.
 ///
 /// This struct is very comparable to [`SyncData`],
 /// but it supports reads and writes
@@ -74,4 +76,11 @@ impl<T> AsRef<BulkData<T>> for BulkData<T> {
 	fn as_ref(&self) -> &Self {
 		self
 	}
+}
+
+/// The data response giving by a motor in response to a bulk read command.
+#[derive(Debug)]
+pub struct BulkResponse<T> {
+	pub response: Response<T>,
+	pub address: u16,
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -81,6 +81,9 @@ impl<T> AsRef<BulkData<T>> for BulkData<T> {
 /// The data response giving by a motor in response to a bulk read command.
 #[derive(Debug)]
 pub struct BulkResponse<T> {
+	/// The response message.
 	pub response: Response<T>,
+	
+	/// The address of the bulk read/write.
 	pub address: u16,
 }

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -28,7 +28,7 @@ where
 			motor_id: status_packet.packet_id(),
 			model: crate::endian::read_u16_le(&parameters[0..]),
 			firmware: crate::endian::read_u8_le(&parameters[2..]),
-			alert: status_packet.error() & 0x80 != 0,
+			alert: status_packet.alert(),
 		}
 	}
 }

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -1,5 +1,5 @@
 use super::{instruction_id, packet_id};
-use crate::{Bus, ReadError, TransferError, WriteError};
+use crate::{bus::StatusPacket, Bus, ReadError, TransferError, WriteError};
 
 #[derive(Debug, Clone)]
 pub struct PingResponse {
@@ -13,6 +13,24 @@ pub struct PingResponse {
 
 	/// The firmware version of the motor.
 	pub firmware: u8,
+
+	pub alert: bool,
+}
+
+impl<'a, ReadBuffer, WriteBuffer> From<StatusPacket<'a, ReadBuffer, WriteBuffer>> for PingResponse
+where
+	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
+	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	fn from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Self {
+		let parameters = status_packet.parameters();
+		Self {
+			motor_id: status_packet.packet_id(),
+			model: crate::endian::read_u16_le(&parameters[0..]),
+			firmware: crate::endian::read_u8_le(&parameters[2..]),
+			alert: status_packet.error() & 0x80 != 0,
+		}
+	}
 }
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
@@ -26,7 +44,7 @@ where
 	/// Use [`Self::scan`] or [`Self::scan_cb`] instead.
 	pub fn ping(&mut self, motor_id: u8) -> Result<PingResponse, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::PING, 0, |_| ())?;
-		Ok(parse_ping_response(response.packet_id(), response.parameters()))
+		Ok(response.into())
 	}
 
 	/// Scan a bus for motors with a broadcast ping, returning the responses in a [`Vec`].
@@ -56,25 +74,17 @@ where
 			let response = self.read_status_response();
 			if let Err(ReadError::Io(e)) = &response {
 				if e.kind() == std::io::ErrorKind::TimedOut {
+					trace!("Response timed out.");
 					continue;
 				}
 			}
 			let response = response.and_then(|response| {
 				crate::InvalidParameterCount::check(response.parameters().len(), 3)?;
-				Ok(parse_ping_response(response.packet_id(), response.parameters()))
+				Ok(response.into())
 			});
 			on_response(response);
 		}
 
 		Ok(())
-	}
-}
-
-/// Parse a ping response from the motor ID and status response parameters.
-fn parse_ping_response(motor_id: u8, parameters: &[u8]) -> PingResponse {
-	PingResponse {
-		motor_id,
-		model: crate::endian::read_u16_le(&parameters[0..]),
-		firmware: crate::endian::read_u8_le(&parameters[2..]),
 	}
 }

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -1,7 +1,7 @@
 use super::{instruction_id, packet_id};
 use crate::{bus::StatusPacket, Bus, ReadError, TransferError, WriteError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PingResponse {
 	/// The ID of the motor.
 	pub motor_id: u8,

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -8,7 +8,7 @@ where
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
 {
 	/// Read an arbitrary number of bytes from multiple motors.
-	fn _read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
+	fn read_raw(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -22,7 +22,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<Response<Vec<u8>>, TransferError> {
-		let response = self._read(motor_id, address, count)?;
+		let response = self.read_raw(motor_id, address, count)?;
 		Ok(response.into())
 	}
 
@@ -31,7 +31,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<Response<u8>, TransferError> {
-		let response = self._read(motor_id, address, 1)?;
+		let response = self.read_raw(motor_id, address, 1)?;
 		Ok(response.into())
 	}
 
@@ -40,7 +40,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<Response<u16>, TransferError> {
-		let response = self._read(motor_id, address, 2)?;
+		let response = self.read_raw(motor_id, address, 2)?;
 		Ok(response.into())
 	}
 
@@ -49,7 +49,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<Response<u32>, TransferError> {
-		let response = self._read(motor_id, address, 4)?;
+		let response = self.read_raw(motor_id, address, 4)?;
 		Ok(response.into())
 	}
 }

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -1,33 +1,6 @@
 use super::instruction_id;
-use crate::endian::{read_u8_le, read_u16_le, read_u32_le, write_u16_le};
-use crate::{Bus, TransferError};
-
-pub struct ReadResponse<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	pub(crate) response: crate::Response<'a, ReadBuffer, WriteBuffer>,
-}
-
-impl<'a, ReadBuffer, WriteBuffer> ReadResponse<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	/// Get the ID of the motor.
-	pub fn motor_id(&self) -> u8 {
-		self.response.packet_id()
-	}
-
-	/// Get the read data as byte slice.
-	///
-	/// The individual registers of the motor are encoded as little-endian.
-	/// Refer to the online manual of your motor for the addresses and sizes of all registers.
-	pub fn data(&self) -> &[u8] {
-		self.response.parameters()
-	}
-}
+use crate::endian::write_u16_le;
+use crate::{bus::StatusPacket, Bus, Response, TransferError};
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
 where
@@ -38,39 +11,39 @@ where
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<ReadResponse<ReadBuffer, WriteBuffer>, TransferError> {
+	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), count.into()).map_err(crate::ReadError::from)?;
-		Ok(ReadResponse { response })
+		Ok(response)
 	}
 
 	/// Read an 8 bit register from a specific motor.
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<u8, TransferError> {
+	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<Response<u8>, TransferError> {
 		let response = self.read(motor_id, address, 1)?;
-		Ok(read_u8_le(response.data()))
+		Ok(response.into())
 	}
 
 	/// Read 16 bit register from a specific motor.
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<u16, TransferError> {
+	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<Response<u16>, TransferError> {
 		let response = self.read(motor_id, address, 2)?;
-		Ok(read_u16_le(response.data()))
+		Ok(response.into())
 	}
 
 	/// Read 32 bit register from a specific motor.
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<u32, TransferError> {
+	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<Response<u32>, TransferError> {
 		let response = self.read(motor_id, address, 4)?;
-		Ok(read_u32_le(response.data()))
+		Ok(response.into())
 	}
 }

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -32,7 +32,7 @@ where
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<Response<u8>, TransferError> {
 		let response = self.read_raw(motor_id, address, 1)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Read 16 bit register from a specific motor.
@@ -41,7 +41,7 @@ where
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<Response<u16>, TransferError> {
 		let response = self.read_raw(motor_id, address, 2)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Read 32 bit register from a specific motor.
@@ -50,6 +50,6 @@ where
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<Response<u32>, TransferError> {
 		let response = self.read_raw(motor_id, address, 4)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 }

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -7,11 +7,8 @@ where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
 {
-	/// Read an arbitrary number of bytes from a specific motor.
-	///
-	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
-	/// Use [`Self::sync_read`] to read from multiple motors with one command.
-	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
+	/// Read an arbitrary number of bytes from multiple motors.
+	fn _read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);
@@ -20,12 +17,21 @@ where
 		Ok(response)
 	}
 
+	/// Read an arbitrary number of bytes from a specific motor.
+	///
+	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
+	/// Use [`Self::sync_read`] to read from multiple motors with one command.
+	pub fn read(&mut self, motor_id: u8, address: u16, count: u16) -> Result<Response<Vec<u8>>, TransferError> {
+		let response = self._read(motor_id, address, count)?;
+		Ok(response.into())
+	}
+
 	/// Read an 8 bit register from a specific motor.
 	///
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u8(&mut self, motor_id: u8, address: u16) -> Result<Response<u8>, TransferError> {
-		let response = self.read(motor_id, address, 1)?;
+		let response = self._read(motor_id, address, 1)?;
 		Ok(response.into())
 	}
 
@@ -34,7 +40,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u16(&mut self, motor_id: u8, address: u16) -> Result<Response<u16>, TransferError> {
-		let response = self.read(motor_id, address, 2)?;
+		let response = self._read(motor_id, address, 2)?;
 		Ok(response.into())
 	}
 
@@ -43,7 +49,7 @@ where
 	/// This function will not work correctly if the motor ID is set to [`packet_id::BROADCAST`][crate::instructions::packet_id::BROADCAST].
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_u32(&mut self, motor_id: u8, address: u16) -> Result<Response<u32>, TransferError> {
-		let response = self.read(motor_id, address, 4)?;
+		let response = self._read(motor_id, address, 4)?;
 		Ok(response.into())
 	}
 }

--- a/src/instructions/reboot.rs
+++ b/src/instructions/reboot.rs
@@ -16,8 +16,7 @@ where
 	/// Instead use [`Self::broadcast_reboot`].
 	pub fn reboot(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::REBOOT, 0, |_| ())?;
-		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Broadcast an reboot command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/reboot.rs
+++ b/src/instructions/reboot.rs
@@ -12,17 +12,12 @@ where
 	/// When a motor reboots, all volatile (non-EEPROM) registers are reset to their initial value.
 	/// This also has the effect of disabling motor torque and resetting the multi-revolution information.
 	///
-	/// The `motor_id` parameter may be set to [`packet_id::BROADCAST`],
-	/// although the [`Self::broadcast_reboot`] is generally easier to use.
-	pub fn reboot(&mut self, motor_id: u8) -> Result<Option<Response<()>>, TransferError> {
-		if motor_id == packet_id::BROADCAST {
-			self.broadcast_action()?;
-			Ok(None)
-		} else {
-			let response = self.transfer_single(motor_id, instruction_id::REBOOT, 0, |_| ())?;
-			crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-			Ok(Some(response.into()))
-		}
+	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
+	/// Instead use [`Self::broadcast_reboot`].
+	pub fn reboot(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
+		let response = self.transfer_single(motor_id, instruction_id::REBOOT, 0, |_| ())?;
+		crate::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
+		Ok(response.into())
 	}
 
 	/// Broadcast an reboot command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/reg_write.rs
+++ b/src/instructions/reg_write.rs
@@ -1,5 +1,5 @@
 use super::instruction_id;
-use crate::{Bus, TransferError};
+use crate::{Bus, Response, TransferError};
 
 use crate::endian::{write_u16_le, write_u32_le};
 
@@ -14,13 +14,13 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
-	pub fn reg_write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<(), TransferError> {
+	pub fn reg_write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + data.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Register a write command for a 8 bit value to a specific motor.
@@ -29,13 +29,13 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
-	pub fn reg_write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<(), TransferError> {
+	pub fn reg_write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 1, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Register a write command for a 16 bit value to a specific motor.
@@ -44,13 +44,13 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
-	pub fn reg_write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<(), TransferError> {
+	pub fn reg_write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 2, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Register a write command for a 32 bit value to a specific motor.
@@ -59,12 +59,12 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
-	pub fn reg_write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<(), TransferError> {
+	pub fn reg_write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 }

--- a/src/instructions/reg_write.rs
+++ b/src/instructions/reg_write.rs
@@ -19,8 +19,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Register a write command for a 8 bit value to a specific motor.
@@ -34,8 +33,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Register a write command for a 16 bit value to a specific motor.
@@ -49,8 +47,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Register a write command for a 32 bit value to a specific motor.
@@ -64,7 +61,6 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 }

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -52,8 +52,7 @@ where
 		for &motor_id in motor_ids {
 			let data = self.read_status_response().and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
-				crate::InvalidParameterCount::check(response.parameters().len(), count)?;
-				Ok(response.into())
+				Ok(response.try_into()?)
 			});
 			on_response(data);
 		}
@@ -77,8 +76,7 @@ where
 		for &motor_id in motor_ids {
 			let data = self.read_status_response().and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
-				crate::InvalidParameterCount::check(response.parameters().len(), count)?;
-				Ok(response.into())
+				Ok(response.try_into()?)
 			});
 			on_response(data);
 		}
@@ -103,7 +101,7 @@ where
 			let data = self.read_status_response().and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
 				crate::InvalidParameterCount::check(response.parameters().len(), count)?;
-				Ok(response.into())
+				Ok(response.try_into()?)
 			});
 			on_response(data);
 		}

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -68,7 +68,7 @@ where
 	where
 		F: FnMut(Result<Response<u16>, ReadError>),
 	{
-		let count = 1;
+		let count = 2;
 		self.write_instruction(packet_id::BROADCAST, instruction_id::SYNC_READ, 4 + motor_ids.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count as u16);

--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -1,4 +1,4 @@
-use super::{instruction_id, packet_id, SyncData};
+use super::{instruction_id, packet_id, SyncWriteData};
 use crate::endian::{write_u16_le, write_u32_le};
 use crate::{Bus, WriteError};
 
@@ -19,7 +19,7 @@ where
 	where
 		Iter: IntoIterator<Item = Data>,
 		Iter::IntoIter: std::iter::ExactSizeIterator,
-		Data: AsRef<SyncData<&'a [u8]>>,
+		Data: AsRef<SyncWriteData<&'a [u8]>>,
 	{
 		let data = data.into_iter();
 		let motors = data.len();
@@ -46,7 +46,7 @@ where
 	where
 		Iter: IntoIterator<Item = Data>,
 		Iter::IntoIter: std::iter::ExactSizeIterator,
-		Data: AsRef<SyncData<u8>>,
+		Data: AsRef<SyncWriteData<u8>>,
 	{
 		let data = data.into_iter();
 		let count = core::mem::size_of::<u8>();
@@ -73,7 +73,7 @@ where
 	where
 		Iter: IntoIterator<Item = Data>,
 		Iter::IntoIter: std::iter::ExactSizeIterator,
-		Data: AsRef<SyncData<u16>>,
+		Data: AsRef<SyncWriteData<u16>>,
 	{
 		let data = data.into_iter();
 		let count = core::mem::size_of::<u16>();
@@ -100,7 +100,7 @@ where
 	where
 		Iter: IntoIterator<Item = Data>,
 		Iter::IntoIter: std::iter::ExactSizeIterator,
-		Data: AsRef<SyncData<u32>>,
+		Data: AsRef<SyncWriteData<u32>>,
 	{
 		let data = data.into_iter();
 		let count = core::mem::size_of::<u32>();

--- a/src/instructions/write.rs
+++ b/src/instructions/write.rs
@@ -1,6 +1,6 @@
 use super::instruction_id;
 use crate::endian::{write_u16_le, write_u32_le};
-use crate::{Bus, TransferError};
+use crate::{Bus, Response, TransferError};
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
 where
@@ -8,42 +8,42 @@ where
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
 {
 	/// Write an arbitrary number of bytes to a specific motor.
-	pub fn write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<(), TransferError> {
+	pub fn write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + data.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Write an 8 bit value to a specific motor.
-	pub fn write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<(), TransferError> {
+	pub fn write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 1, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Write an 16 bit value to a specific motor.
-	pub fn write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<(), TransferError> {
+	pub fn write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 2, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 
 	/// Write an 32 bit value to a specific motor.
-	pub fn write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<(), TransferError> {
+	pub fn write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<Response<()>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
 		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(())
+		Ok(response.into())
 	}
 }

--- a/src/instructions/write.rs
+++ b/src/instructions/write.rs
@@ -13,8 +13,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Write an 8 bit value to a specific motor.
@@ -23,8 +22,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Write an 16 bit value to a specific motor.
@@ -33,8 +31,7 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 
 	/// Write an 32 bit value to a specific motor.
@@ -43,7 +40,6 @@ where
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
-		crate::error::InvalidParameterCount::check(response.parameters().len(), 0).map_err(crate::ReadError::from)?;
-		Ok(response.into())
+		Ok(response.try_into()?)
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,4 +43,3 @@ pub use error::WriteError;
 
 pub use bus::Bus;
 pub use bus::Response;
-pub use instructions::BulkResponse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,4 @@ pub use error::WriteError;
 
 pub use bus::Bus;
 pub use bus::Response;
+pub use instructions::BulkResponse;


### PR DESCRIPTION
This allows for the reading of the alert bit to check for hardware errors
Key changes:
- Renamed `Response` struct to `StatusPacket`
- Added a new generic struct called `Response`
  - This contains the `motor_id`, some generically typed data, an alert bit for checking hardware errors, and an optional address used for bulkdata reads
- changed all pub functions to return a `Response`
- changed sync_read and bulk_read functions to return the Response Struct, instead of SyncData/BulkData
- 
A few things I'm unsure about at the moment:

1. the `read` function still returns a `StatusPacket` struct, its the only pub fn to do so. 
   - I left it this way to eliminate an extra memory allocation:
   - ie when `read_u8` is called, I didn't want to have read creating a `Response<Vec<u8>>` for it just to be converted into a `Response<u8>`.
   - This means, however, that if read is called by the user is returns a StatusPacket.
   - I might add a private _read function to get around this issue.

2. The `action`, `clear`, `factory_reset`, and `reboot` functions return `Result<Option<Response<()>>, crate::TransferError>`

   - The option is to due to the broadcast function it calls, 
   - It might be better to panic! if motor_id == 254 and instead only allow dedicated broadcast functions to be used.

3. The `address: Option<u16>` field of the `Response` struct is only used for `bulk_read`

   - I wanted to simply the number of structs being returned but as the address field is only used to this it makes more sense to create a new struct.