### PR TITLE
Reexport serial2

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ pub enum InvalidMessage {
 }
 
 /// An error reported by the motor.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct MotorError {
 	pub raw: u8,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ pub enum InvalidMessage {
 }
 
 /// An error reported by the motor.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct MotorError {
 	pub raw: u8,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum ReadError {
 }
 
 /// The received message is not valid.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum InvalidMessage {
 	InvalidHeaderPrefix(InvalidHeaderPrefix),
 	InvalidChecksum(InvalidChecksum),
@@ -33,6 +33,7 @@ pub enum InvalidMessage {
 }
 
 /// An error reported by the motor.
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct MotorError {
 	pub raw: u8,
 }
@@ -63,46 +64,45 @@ impl std::fmt::Debug for MotorError {
 			.field("alert", &self.alert())
 			.finish()
 	}
-
 }
 
 /// The received message has an invalid header prefix.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct InvalidHeaderPrefix {
 	pub actual: [u8; 4],
 	pub expected: [u8; 4],
 }
 
 /// The received message has an invalid checksum value.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct InvalidChecksum {
 	pub message: u16,
 	pub computed: u16,
 }
 
 /// The received message has an invalid or unexpected packet ID.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct InvalidPacketId {
 	pub actual: u8,
 	pub expected: Option<u8>,
 }
 
 /// The received message has an invalid or unexpected instruction value.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct InvalidInstruction {
 	pub actual: u8,
 	pub expected: u8,
 }
 
 /// The expected number of parameters.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ExpectedCount {
 	Exact(usize),
 	Max(usize),
 }
 
 /// The received message has an invalid or unexpected parameter count.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct InvalidParameterCount {
 	pub actual: usize,
 	pub expected: ExpectedCount,

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -38,6 +38,7 @@ pub use ping::PingResponse;
 /// Data from or for a specific motor.
 ///
 /// Used by synchronous write commands.
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct SyncWriteData<T> {
 	/// The ID of the motor.
 	pub motor_id: u8,

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -38,7 +38,7 @@ pub use ping::PingResponse;
 /// Data from or for a specific motor.
 ///
 /// Used by synchronous write commands.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SyncWriteData<T> {
 	/// The ID of the motor.
 	pub motor_id: u8,

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -2,7 +2,7 @@ use super::{instruction_id, packet_id};
 use crate::bus::StatusPacket;
 use crate::{Bus, ReadError, TransferError, WriteError};
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PingResponse {
 	/// The ID of the motor.
 	pub motor_id: u8,

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -2,7 +2,7 @@ use super::{instruction_id, packet_id};
 use crate::bus::StatusPacket;
 use crate::{Bus, ReadError, TransferError, WriteError};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
 pub struct PingResponse {
 	/// The ID of the motor.
 	pub motor_id: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,5 @@ pub use error::WriteError;
 
 pub use bus::Bus;
 pub use bus::Response;
+
+pub use serial2::SerialPort;


### PR DESCRIPTION
A pr to fix some issues I have been having.

* Re export the serial2::SerialPort for use in the Bus::new constructor.
* Add more common std derives to the pub structs (following the advice in the [rust api guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits) 