### PR TITLE
Allow using the broadcast ID with more functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [major][change] Remove `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`.
+
 # Version 0.7.2 - 2024-03-24
 - [minor][add] Expose `ExpectedCount` publically.
 - [minor][add] Implement `Debug` for `Bus`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Unreleased
 - [major][change] Remove `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`.
+- [minor][add] Allow using the broadcast ID with the `write()`, `write_u8()`, `write_u16` and `write_u32` functions.
+- [minor][add] Allow using the broadcast ID with the `reg_write()`, `reg_write_u8()`, `reg_write_u16` and `reg_write_u32` functions.
+- [minor][add] Allow using the broadcast ID with the `action()` function.
+- [minor][add] Allow using the broadcast ID with the `clear_revolution_counter()` function.
+- [minor][add] Allow using the broadcast ID with the `factory_reset()` function.
+- [minor][add] Allow using the broadcast ID with the `reboot()` function.
 
 # Version 0.7.2 - 2024-03-24
 - [minor][add] Expose `ExpectedCount` publically.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 # Unreleased
 - [major][change] Remove `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`.
+- [major][add] Add `WriteError::BufferFull` and `ReadError::BufferFull` variants.
+- [minor][change] Report full buffers as `BufferFullError` instead of panicking.
 - [minor][add] Allow using the broadcast ID with the `write()`, `write_u8()`, `write_u16` and `write_u32` functions.
 - [minor][add] Allow using the broadcast ID with the `reg_write()`, `reg_write_u8()`, `reg_write_u16` and `reg_write_u32` functions.
 - [minor][add] Allow using the broadcast ID with the `action()` function.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -25,6 +25,9 @@ pub struct Bus<ReadBuffer, WriteBuffer> {
 	/// The total number of valid bytes in the read buffer.
 	read_len: usize,
 
+	/// The number of leading bytes in the read buffer that have already been used.
+	used_bytes: usize,
+
 	/// The buffer for outgoing messages.
 	write_buffer: WriteBuffer,
 }
@@ -32,6 +35,7 @@ pub struct Bus<ReadBuffer, WriteBuffer> {
 impl<ReadBuffer, WriteBuffer> std::fmt::Debug for Bus<ReadBuffer, WriteBuffer> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		#[derive(Debug)]
+		#[allow(dead_code)] // Dead code analisys ignores derive debug impls, but thats the whole point of this struct.
 		enum Raw {
 			#[cfg(unix)]
 			Fd(std::os::unix::io::RawFd),
@@ -106,6 +110,7 @@ where
 			read_timeout,
 			read_buffer,
 			read_len: 0,
+			used_bytes: 0,
 			write_buffer,
 		}
 	}
@@ -123,7 +128,7 @@ where
 		instruction_id: u8,
 		parameter_count: usize,
 		encode_parameters: F,
-	) -> Result<StatusPacket<ReadBuffer, WriteBuffer>, TransferError>
+	) -> Result<StatusPacket<'_>, TransferError>
 	where
 		F: FnOnce(&mut [u8]),
 	{
@@ -184,7 +189,7 @@ where
 	}
 
 	/// Read a raw status response from the bus.
-	pub fn read_status_response(&mut self) -> Result<StatusPacket<ReadBuffer, WriteBuffer>, ReadError> {
+	pub fn read_status_response(&mut self) -> Result<StatusPacket, ReadError> {
 		let deadline = Instant::now() + self.read_timeout;
 		let stuffed_message_len = loop {
 			self.remove_garbage();
@@ -233,14 +238,15 @@ where
 			.into());
 		}
 
+		// Mark the whole message as "used_bytes", so that the next call to `remove_garbage()` removes it.
+		self.used_bytes += stuffed_message_len;
+
 		// Remove byte-stuffing from the parameters.
 		let parameter_count = bytestuff::unstuff_inplace(&mut buffer[STATUS_HEADER_SIZE..parameters_end]);
 
-		// Creating the status packet struct here means that the data gets purged from the buffer even if we return early using the try operator.
+		// Wrap the data in a `StatusPacket`.
 		let response = StatusPacket {
-			bus: self,
-			stuffed_message_len,
-			parameter_count,
+			data: &self.read_buffer.as_ref()[..STATUS_HEADER_SIZE + parameter_count],
 		};
 
 		crate::InvalidInstruction::check(response.instruction_id(), crate::instructions::instruction_id::STATUS)?;
@@ -257,17 +263,22 @@ where
 	/// Remove leading garbage data from the read buffer.
 	fn remove_garbage(&mut self) {
 		let read_buffer = self.read_buffer.as_mut();
-		let garbage_len = find_header(&read_buffer[..self.read_len]);
+		let garbage_len = find_header(&read_buffer[..self.read_len][self.used_bytes..]);
 		if garbage_len > 0 {
 			debug!("skipping {} bytes of leading garbage.", garbage_len);
 			trace!("skipped garbage: {:02X?}", &read_buffer[..garbage_len]);
 		}
-		self.consume_read_bytes(garbage_len);
+		self.consume_read_bytes(self.used_bytes + garbage_len);
+		debug_assert_eq!(self.used_bytes, 0);
 	}
 
 	fn consume_read_bytes(&mut self, len: usize) {
 		debug_assert!(len <= self.read_len);
 		self.read_buffer.as_mut().copy_within(len..self.read_len, 0);
+		// Decrease both used_bytes and read_len together.
+		// Some consumed bytes may be garbage instead of used bytes though.
+		// So we use `saturating_sub` for `used_bytes` to cap the result at 0.
+		self.used_bytes = self.used_bytes.saturating_sub(len);
 		self.read_len -= len;
 	}
 }
@@ -276,32 +287,18 @@ where
 ///
 /// When dropped, the response data is removed from the read buffer.
 #[derive(Debug)]
-pub struct StatusPacket<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	/// The bus that read the message.
-	bus: &'a mut Bus<ReadBuffer, WriteBuffer>,
-
-	/// The total length of the stuffed message.
-	stuffed_message_len: usize,
-
-	/// The number of parameters after removing byte-stuffing.
-	parameter_count: usize,
+pub struct StatusPacket<'a> {
+	/// Message data (with byte-stuffing already undone).
+	data: &'a [u8],
 }
 
-impl<'a, ReadBuffer, WriteBuffer> StatusPacket<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> StatusPacket<'a> {
 	/// Get the raw bytes of the message.
 	///
 	/// This includes the message header and the parameters.
 	/// It does not include the CRC or byte-stuffing.
 	pub fn as_bytes(&self) -> &[u8] {
-		&self.bus.read_buffer.as_ref()[..STATUS_HEADER_SIZE + self.parameter_count]
+		self.data
 	}
 
 	/// The packet ID of the response.
@@ -338,17 +335,7 @@ where
 
 	/// The parameters of the response.
 	pub fn parameters(&self) -> &[u8] {
-		&self.as_bytes()[STATUS_HEADER_SIZE..][..self.parameter_count]
-	}
-}
-
-impl<'a, ReadBuffer, WriteBuffer> Drop for StatusPacket<'a, ReadBuffer, WriteBuffer>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	fn drop(&mut self) {
-		self.bus.consume_read_bytes(self.stuffed_message_len);
+		&self.data[STATUS_HEADER_SIZE..]
 	}
 }
 
@@ -387,15 +374,11 @@ pub struct Response<T> {
 	pub data: T,
 }
 
-impl<'a, ReadBuffer, WriteBuffer> TryFrom<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<()>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> TryFrom<StatusPacket<'a>> for Response<()> {
 	type Error = crate::InvalidParameterCount;
 
-	fn try_from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Result<Self, Self::Error> {
-		crate::InvalidParameterCount::check(status_packet.parameter_count, 0)?;
+	fn try_from(status_packet: StatusPacket<'a>) -> Result<Self, Self::Error> {
+		crate::InvalidParameterCount::check(status_packet.parameters().len(), 0)?;
 		Ok(Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
@@ -404,12 +387,8 @@ where
 	}
 }
 
-impl<'a, 'b, ReadBuffer, WriteBuffer> From<&'b StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<&'b [u8]>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	fn from(status_packet: &'b StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Self {
+impl<'a, 'b> From<&'b StatusPacket<'a>> for Response<&'b [u8]> {
+	fn from(status_packet: &'b StatusPacket<'a>) -> Self {
 		Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
@@ -418,12 +397,8 @@ where
 	}
 }
 
-impl<'a, ReadBuffer, WriteBuffer> From<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<Vec<u8>>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
-	fn from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Self {
+impl<'a> From<StatusPacket<'a>> for Response<Vec<u8>> {
+	fn from(status_packet: StatusPacket<'a>) -> Self {
 		Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
@@ -432,15 +407,11 @@ where
 	}
 }
 
-impl<'a, ReadBuffer, WriteBuffer> TryFrom<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<u8>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> TryFrom<StatusPacket<'a>> for Response<u8> {
 	type Error = crate::InvalidParameterCount;
 
-	fn try_from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Result<Self, Self::Error> {
-		crate::InvalidParameterCount::check(status_packet.parameter_count, 1)?;
+	fn try_from(status_packet: StatusPacket<'a>) -> Result<Self, Self::Error> {
+		crate::InvalidParameterCount::check(status_packet.parameters().len(), 1)?;
 		Ok(Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
@@ -449,15 +420,11 @@ where
 	}
 }
 
-impl<'a, ReadBuffer, WriteBuffer> TryFrom<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<u16>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> TryFrom<StatusPacket<'a>> for Response<u16> {
 	type Error = crate::InvalidParameterCount;
 
-	fn try_from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Result<Self, Self::Error> {
-		crate::InvalidParameterCount::check(status_packet.parameter_count, 2)?;
+	fn try_from(status_packet: StatusPacket<'a>) -> Result<Self, Self::Error> {
+		crate::InvalidParameterCount::check(status_packet.parameters().len(), 2)?;
 		Ok(Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),
@@ -466,15 +433,11 @@ where
 	}
 }
 
-impl<'a, ReadBuffer, WriteBuffer> TryFrom<StatusPacket<'a, ReadBuffer, WriteBuffer>> for Response<u32>
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> TryFrom<StatusPacket<'a>> for Response<u32> {
 	type Error = crate::InvalidParameterCount;
 
-	fn try_from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Result<Self, Self::Error> {
-		crate::InvalidParameterCount::check(status_packet.parameter_count, 4)?;
+	fn try_from(status_packet: StatusPacket<'a>) -> Result<Self, Self::Error> {
+		crate::InvalidParameterCount::check(status_packet.parameters().len(), 4)?;
 		Ok(Self {
 			motor_id: status_packet.packet_id(),
 			alert: status_packet.alert(),

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -176,6 +176,7 @@ where
 		// We don't do this when reading a reply, because we might multiple replies for one instruction,
 		// and read() can potentially read more than one reply per syscall.
 		self.read_len = 0;
+		self.used_bytes = 0;
 		self.serial_port.discard_input_buffer().map_err(WriteError::DiscardBuffer)?;
 
 		// Send message.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -152,7 +152,7 @@ where
 		let buffer = self.write_buffer.as_mut();
 
 		// Check if the buffer can hold the unstuffed message.
-		crate::error::BufferFullError::check(HEADER_SIZE + parameter_count + 2, buffer.len())?;
+		crate::error::BufferTooSmallError::check(HEADER_SIZE + parameter_count + 2, buffer.len())?;
 
 		// Add the header, with a placeholder for the length field.
 		buffer[4] = packet_id;
@@ -189,7 +189,7 @@ where
 	/// Read a raw status response from the bus.
 	pub fn read_status_response(&mut self) -> Result<StatusPacket, ReadError> {
 		// Check that the read buffer is large enough to hold atleast a status packet header.
-		crate::error::BufferFullError::check(STATUS_HEADER_SIZE, self.read_buffer.as_mut().len())?;
+		crate::error::BufferTooSmallError::check(STATUS_HEADER_SIZE, self.read_buffer.as_mut().len())?;
 
 		let deadline = Instant::now() + self.read_timeout;
 		let stuffed_message_len = loop {
@@ -204,7 +204,7 @@ where
 
 				// Check if the read buffer is large enough for the entire message.
 				// We don't have to remove the read bytes, because `write_instruction()` already clears the read buffer.
-				crate::error::BufferFullError::check(STATUS_HEADER_SIZE + body_len, self.read_buffer.as_mut().len())?;
+				crate::error::BufferTooSmallError::check(STATUS_HEADER_SIZE + body_len, self.read_buffer.as_mut().len())?;
 
 				if self.read_len >= STATUS_HEADER_SIZE + body_len {
 					break STATUS_HEADER_SIZE + body_len;

--- a/src/bytestuff.rs
+++ b/src/bytestuff.rs
@@ -1,6 +1,6 @@
 //! Byte-stuffing and de-stuffing.
 
-use crate::error::BufferFullError;
+use crate::error::BufferTooSmallError;
 
 pub const PATTERN: [u8; 4] = [0xFF, 0xFF, 0xFD, 0xFD];
 
@@ -54,7 +54,7 @@ pub fn stuffing_required(data: &[u8]) -> usize {
 ///
 /// The full buffer must be large enough to hold the stuffed data,
 /// or an error is returned.
-pub fn stuff_inplace(buffer: &mut [u8], len: usize) -> Result<usize, BufferFullError> {
+pub fn stuff_inplace(buffer: &mut [u8], len: usize) -> Result<usize, BufferTooSmallError> {
 	let stuffing_required = stuffing_required(&buffer[..len]);
 	if stuffing_required == 0 {
 		return Ok(len);
@@ -63,7 +63,7 @@ pub fn stuff_inplace(buffer: &mut [u8], len: usize) -> Result<usize, BufferFullE
 	let mut read = 0;
 	let mut stuffing_applied = 0;
 
-	BufferFullError::check(len + stuffing_required, buffer.len())?;
+	BufferTooSmallError::check(len + stuffing_required, buffer.len())?;
 
 	while read < len && stuffing_applied < stuffing_required {
 		let read_pos = len - read - 1;
@@ -98,7 +98,7 @@ mod test {
 		unstuffed_length / 3 * 4 + unstuffed_length % 3
 	}
 
-	fn stuff(mut data: Vec<u8>) -> Result<Vec<u8>, BufferFullError> {
+	fn stuff(mut data: Vec<u8>) -> Result<Vec<u8>, BufferTooSmallError> {
 		let used = data.len();
 		data.resize(maximum_stuffed_len(used), 0);
 		let new_size = stuff_inplace(&mut data, used)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum TransferError {
 #[derive(Debug)]
 pub enum WriteError {
 	/// The write buffer is too small to contain the whole stuffed message.
-	BufferFull(BufferFullError),
+	BufferTooSmall(BufferTooSmallError),
 
 	/// Failed to discard the input buffer before writing the instruction.
 	DiscardBuffer(std::io::Error),
@@ -28,7 +28,7 @@ pub enum WriteError {
 /// Consider increasing the size of the buffer.
 /// Keep in mind that the write buffer needs to be large enough to account for byte stuffing.
 #[derive(Debug)]
-pub struct BufferFullError {
+pub struct BufferTooSmallError {
 	/// The required size of the buffer.
 	pub required_size: usize,
 
@@ -40,7 +40,7 @@ pub struct BufferFullError {
 #[derive(Debug)]
 pub enum ReadError {
 	/// The read buffer is too small to contain the whole stuffed message.
-	BufferFull(BufferFullError),
+	BufferFull(BufferTooSmallError),
 
 	/// Failed to read from the serial port.
 	Io(std::io::Error),
@@ -171,7 +171,7 @@ pub struct InvalidParameterCount {
 	pub expected: ExpectedCount,
 }
 
-impl BufferFullError {
+impl BufferTooSmallError {
 	pub fn check(required_size: usize, total_size: usize) -> Result<(), Self> {
 		if required_size <= total_size {
 			Ok(())
@@ -330,14 +330,14 @@ impl From<InvalidParameterCount> for TransferError {
 	}
 }
 
-impl From<BufferFullError> for WriteError {
-	fn from(other: BufferFullError) -> Self {
-		Self::BufferFull(other)
+impl From<BufferTooSmallError> for WriteError {
+	fn from(other: BufferTooSmallError) -> Self {
+		Self::BufferTooSmall(other)
 	}
 }
 
-impl From<BufferFullError> for ReadError {
-	fn from(other: BufferFullError) -> Self {
+impl From<BufferTooSmallError> for ReadError {
+	fn from(other: BufferTooSmallError) -> Self {
 		Self::BufferFull(other)
 	}
 }
@@ -438,7 +438,7 @@ impl std::fmt::Display for TransferError {
 impl std::fmt::Display for WriteError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
-			Self::BufferFull(e) => write!(
+			Self::BufferTooSmall(e) => write!(
 				f,
 				"write buffer is too small: need {} bytes, but the size is {}",
 				e.required_size, e.total_size
@@ -449,7 +449,7 @@ impl std::fmt::Display for WriteError {
 	}
 }
 
-impl std::fmt::Display for BufferFullError {
+impl std::fmt::Display for BufferTooSmallError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(
 			f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -176,10 +176,7 @@ impl BufferFullError {
 		if required_size <= total_size {
 			Ok(())
 		} else {
-			Err(Self {
-				required_size,
-				total_size,
-			})
+			Err(Self { required_size, total_size })
 		}
 	}
 }
@@ -441,7 +438,11 @@ impl std::fmt::Display for TransferError {
 impl std::fmt::Display for WriteError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
-			Self::BufferFull(e) => write!(f, "write buffer is too small: need {} bytes, but the size is {}", e.required_size, e.total_size),
+			Self::BufferFull(e) => write!(
+				f,
+				"write buffer is too small: need {} bytes, but the size is {}",
+				e.required_size, e.total_size
+			),
 			Self::DiscardBuffer(e) => write!(f, "failed to discard input buffer: {}", e),
 			Self::Write(e) => write!(f, "failed to write to serial port: {}", e),
 		}
@@ -450,14 +451,22 @@ impl std::fmt::Display for WriteError {
 
 impl std::fmt::Display for BufferFullError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		write!(f, "buffer is too small: need {} bytes, but the size is {}", self.required_size, self.total_size)
+		write!(
+			f,
+			"buffer is too small: need {} bytes, but the size is {}",
+			self.required_size, self.total_size
+		)
 	}
 }
 
 impl std::fmt::Display for ReadError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
-			Self::BufferFull(e) => write!(f, "read buffer is too small: need {} bytes, but the size is {}", e.required_size, e.total_size),
+			Self::BufferFull(e) => write!(
+				f,
+				"read buffer is too small: need {} bytes, but the size is {}",
+				e.required_size, e.total_size
+			),
 			Self::Io(e) => write!(f, "failed to read from serial port: {}", e),
 			Self::InvalidMessage(e) => write!(f, "{}", e),
 			Self::MotorError(e) => write!(f, "{}", e),

--- a/src/instructions/action.rs
+++ b/src/instructions/action.rs
@@ -8,11 +8,13 @@ where
 {
 	/// Send an action command to trigger a previously registered instruction.
 	///
-	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
-	/// Instead use [`Self::broadcast_action`].
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
+	///
+	/// If you want to broadcast this instruction, it may be more convenient to use [`Self::broadcast_action()`] instead.
 	pub fn action(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::ACTION, 0, |_| ())?;
-		Ok(response.try_into()?)
+		self.write_instruction(motor_id, instruction_id::ACTION, 0, |_| ())?;
+		Ok(super::read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Broadcast an action command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -86,7 +86,7 @@ where
 					Ok(response) => responses.push(Response {
 						motor_id: response.motor_id,
 						alert: response.alert,
-						data: response.data.to_owned()
+						data: response.data.to_owned(),
 					}),
 				}
 			}

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -15,11 +15,13 @@ where
 	/// It is not possible to clear the revolution counter of a motor while it is moving.
 	/// Doing so will cause the motor to return an error, and the revolution counter will not be reset.
 	///
-	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
-	/// Instead use [`Self::broadcast_clear_revolution_counter`].
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
+	///
+	/// If you want to broadcast this instruction, it may be more convenient to use [`Self::broadcast_clear_revolution_counter()`] instead.
 	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Response<()>, crate::TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
-		Ok(response.try_into()?)
+		self.write_instruction(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), encode_parameters)?;
+		Ok(super::read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Clear the revolution counter of all connected motors.

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -101,3 +101,25 @@ impl AsRef<BulkReadData> for BulkReadData {
 		self
 	}
 }
+
+/// Read an empty response from the bus if the motor ID is not the broadcast ID.
+///
+/// If the motor ID is the broadcast ID, return a fake response from the broadcast ID.
+fn read_response_if_not_broadcast<ReadBuffer, WriteBuffer>(
+	bus: &mut crate::Bus<ReadBuffer, WriteBuffer>,
+	motor_id: u8,
+) -> Result<crate::Response<()>, crate::error::ReadError>
+where
+	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
+	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	if motor_id == packet_id::BROADCAST {
+		Ok(crate::Response {
+			motor_id: packet_id::BROADCAST,
+			alert: false,
+			data: (),
+		})
+	} else {
+		Ok(bus.read_status_response()?.try_into()?)
+	}
+}

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -23,14 +23,10 @@ pub struct PingResponse {
 	pub alert: bool,
 }
 
-impl<'a, ReadBuffer, WriteBuffer> TryFrom<StatusPacket<'a, ReadBuffer, WriteBuffer>> for PingResponse
-where
-	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-{
+impl<'a> TryFrom<StatusPacket<'a>> for PingResponse {
 	type Error = crate::InvalidParameterCount;
 
-	fn try_from(status_packet: StatusPacket<'a, ReadBuffer, WriteBuffer>) -> Result<Self, Self::Error> {
+	fn try_from(status_packet: StatusPacket<'a>) -> Result<Self, Self::Error> {
 		let parameters = status_packet.parameters();
 		crate::InvalidParameterCount::check(parameters.len(), 3)?;
 		Ok(Self {

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -8,7 +8,7 @@ where
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
 {
 	/// Read an arbitrary number of bytes from multiple motors.
-	fn read_raw(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_, ReadBuffer, WriteBuffer>, TransferError> {
+	fn read_raw(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_>, TransferError> {
 		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);

--- a/src/instructions/reboot.rs
+++ b/src/instructions/reboot.rs
@@ -12,11 +12,13 @@ where
 	/// When a motor reboots, all volatile (non-EEPROM) registers are reset to their initial value.
 	/// This also has the effect of disabling motor torque and resetting the multi-revolution information.
 	///
-	/// The `motor_id` parameter must not be set to [`packet_id::BROADCAST`],
-	/// Instead use [`Self::broadcast_reboot`].
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
+	///
+	/// If you want to broadcast this instruction, it may be more convenient to use [`Self::broadcast_reboot()`] instead.
 	pub fn reboot(&mut self, motor_id: u8) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::REBOOT, 0, |_| ())?;
-		Ok(response.try_into()?)
+		self.write_instruction(motor_id, instruction_id::REBOOT, 0, |_| ())?;
+		Ok(super::read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Broadcast an reboot command to all connected motors to trigger a previously registered instruction.

--- a/src/instructions/reg_write.rs
+++ b/src/instructions/reg_write.rs
@@ -1,4 +1,4 @@
-use super::instruction_id;
+use super::{instruction_id, read_response_if_not_broadcast};
 use crate::{Bus, Response, TransferError};
 
 use crate::endian::{write_u16_le, write_u32_le};
@@ -14,12 +14,15 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn reg_write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + data.len(), |buffer| {
+		self.write_instruction(motor_id, instruction_id::REG_WRITE, 2 + data.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Register a write command for a 8 bit value to a specific motor.
@@ -28,12 +31,15 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn reg_write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 1, |buffer| {
+		self.write_instruction(motor_id, instruction_id::REG_WRITE, 2 + 1, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Register a write command for a 16 bit value to a specific motor.
@@ -42,12 +48,15 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn reg_write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 2, |buffer| {
+		self.write_instruction(motor_id, instruction_id::REG_WRITE, 2 + 2, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Register a write command for a 32 bit value to a specific motor.
@@ -56,11 +65,14 @@ where
 	///
 	/// You can have all connected motors execute their registered write using [`Self::broadcast_action`],
 	/// or a single motor using [`Self::action`].
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn reg_write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::REG_WRITE, 2 + 4, |buffer| {
+		self.write_instruction(motor_id, instruction_id::REG_WRITE, 2 + 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 }

--- a/src/instructions/write.rs
+++ b/src/instructions/write.rs
@@ -1,4 +1,4 @@
-use super::instruction_id;
+use super::{instruction_id, read_response_if_not_broadcast};
 use crate::endian::{write_u16_le, write_u32_le};
 use crate::{Bus, Response, TransferError};
 
@@ -8,38 +8,50 @@ where
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
 {
 	/// Write an arbitrary number of bytes to a specific motor.
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn write(&mut self, motor_id: u8, address: u16, data: &[u8]) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + data.len(), |buffer| {
+		self.write_instruction(motor_id, instruction_id::WRITE, 2 + data.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2..].copy_from_slice(data)
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Write an 8 bit value to a specific motor.
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn write_u8(&mut self, motor_id: u8, address: u16, value: u8) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 1, |buffer| {
+		self.write_instruction(motor_id, instruction_id::WRITE, 2 + 1, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			buffer[2] = value;
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Write an 16 bit value to a specific motor.
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn write_u16(&mut self, motor_id: u8, address: u16, value: u16) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 2, |buffer| {
+		self.write_instruction(motor_id, instruction_id::WRITE, 2 + 2, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], value);
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 
 	/// Write an 32 bit value to a specific motor.
+	///
+	/// You may specify [`crate::instructions::packet_id::BROADCAST`] as motor ID.
+	/// If you do, none of the devices will reply with a response, and this function will not wait for any.
 	pub fn write_u32(&mut self, motor_id: u8, address: u16, value: u32) -> Result<Response<()>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::WRITE, 2 + 4, |buffer| {
+		self.write_instruction(motor_id, instruction_id::WRITE, 2 + 4, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u32_le(&mut buffer[2..], value);
 		})?;
-		Ok(response.try_into()?)
+		Ok(read_response_if_not_broadcast(self, motor_id)?)
 	}
 }


### PR DESCRIPTION
This PR changes the functions for instructions that do not return any data.

If the motor ID is the broadcast ID, the functions will no longer wait for a response (and then get a timeout). Instead, the functions will return directly after writing the command with a fake response from the broadcast ID.

Additionally (but unrelated), this PR removes the `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`, which should make it a more friendly type to work with. It moves the bookkeeping for used bytes into the `Bus` struct to allow for this.

Also unrelated, this PR handles full buffers by returning a `BufferFullError` instead of panicking.

@omelia-iliffe: When you have the time, could you verify that communication is still working with this PR? The changes to `StatusPacket` are a bit risky considering this kind of bookkeeping is error prone.