### PR TITLE
ease of use improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# Unreleased
+- [minor][add] Allow direct access to the underlying serial port.
+- [major][change] Change `bulk_write()` to take an iterator instead of a slice.
+- [major][change] Change `sync_read()` to accept any buffer type that implements `AsRef<[u8]>`.
+
 # Version 0.8.0 - 2024-04-15
 - [major][change] Remove `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`.
 - [major][add] Add `WriteError::BufferTooSmall` and `ReadError::BufferTooSmall` variants.

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -116,6 +116,11 @@ where
 	}
 
 	/// Get a reference to the underlying [`SerialPort`].
+	///
+	/// Note that performing any read or write with the [`SerialPort`] bypasses the read/write buffer of the bus,
+	/// and may disrupt the communication with the motors.
+	/// In general, it should be safe to read and write to the bus manually in between instructions,
+	/// if the response from the motors has already been received.
 	pub fn serial_port(&self) -> &SerialPort {
 		&self.serial_port
 	}
@@ -123,13 +128,18 @@ where
 	/// Get a mutable reference to the underlying [`SerialPort`].
 	///
 	/// Useful if you want to use or configure the serial port directly
+	///
+	/// Note that performing any read or write with the [`SerialPort`] bypasses the read/write buffer of the bus,
+	/// and may disrupt the communication with the motors.
+	/// In general, it should be safe to read and write to the bus manually in between instructions,
+	/// if the response from the motors has already been received.
 	pub fn serial_port_mut(&mut self) -> &mut SerialPort {
 		&mut self.serial_port
 	}
 
-	/// Consume this bus object to get the serial port.
+	/// Consume this bus object to get ownership of the serial port.
 	///
-	/// This discards any data in internal the read buffer of this bus object.
+	/// This discards any data in internal the read buffer of the bus object.
 	/// This is normally not a problem, since all data in the read buffer is also discarded when transmitting a new command.
 	pub fn into_serial_port(self) -> SerialPort {
 		self.serial_port

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -116,14 +116,14 @@ where
 	}
 
     /// Get a reference to the underlying [`SerialPort`].
-    pub fn stream(&self) -> &SerialPort {
+    pub fn serial_port(&self) -> &SerialPort {
         &self.serial_port
     }
 
     /// Get a mutable reference to the underlying [`SerialPort`].
     ///
     /// Useful if you want to use or configure the serial port directly
-    pub fn stream_mut(&mut self) -> &mut SerialPort {
+    pub fn serial_port_mut(&mut self) -> &mut SerialPort {
         &mut self.serial_port
     }
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -115,31 +115,31 @@ where
 		}
 	}
 
-    /// Get a reference to the underlying [`SerialPort`].
-    pub fn serial_port(&self) -> &SerialPort {
-        &self.serial_port
-    }
+	/// Get a reference to the underlying [`SerialPort`].
+	pub fn serial_port(&self) -> &SerialPort {
+		&self.serial_port
+	}
 
-    /// Get a mutable reference to the underlying [`SerialPort`].
-    ///
-    /// Useful if you want to use or configure the serial port directly
-    pub fn serial_port_mut(&mut self) -> &mut SerialPort {
-        &mut self.serial_port
-    }
+	/// Get a mutable reference to the underlying [`SerialPort`].
+	///
+	/// Useful if you want to use or configure the serial port directly
+	pub fn serial_port_mut(&mut self) -> &mut SerialPort {
+		&mut self.serial_port
+	}
 
-    /// Write a raw instruction to a stream, and read a single raw response.
-    ///
-    /// This function also checks that the packet ID of the status response matches the one from the instruction.
-    ///
-    /// This is not suitable for broadcast instructions.
-    /// For broadcast instructions, each motor sends an individual response or no response is send at all.
-    /// Instead, use [`Self::write_instruction`] and [`Self::read_status_response`].
-    pub fn transfer_single<F>(
-        &mut self,
-        packet_id: u8,
-        instruction_id: u8,
-        parameter_count: usize,
-        encode_parameters: F,
+	/// Write a raw instruction to a stream, and read a single raw response.
+	///
+	/// This function also checks that the packet ID of the status response matches the one from the instruction.
+	///
+	/// This is not suitable for broadcast instructions.
+	/// For broadcast instructions, each motor sends an individual response or no response is send at all.
+	/// Instead, use [`Self::write_instruction`] and [`Self::read_status_response`].
+	pub fn transfer_single<F>(
+		&mut self,
+		packet_id: u8,
+		instruction_id: u8,
+		parameter_count: usize,
+		encode_parameters: F,
 	) -> Result<StatusPacket<'_>, TransferError>
 	where
 		F: FnOnce(&mut [u8]),

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -115,19 +115,31 @@ where
 		}
 	}
 
-	/// Write a raw instruction to a stream, and read a single raw response.
-	///
-	/// This function also checks that the packet ID of the status response matches the one from the instruction.
-	///
-	/// This is not suitable for broadcast instructions.
-	/// For broadcast instructions, each motor sends an individual response or no response is send at all.
-	/// Instead, use [`Self::write_instruction`] and [`Self::read_status_response`].
-	pub fn transfer_single<F>(
-		&mut self,
-		packet_id: u8,
-		instruction_id: u8,
-		parameter_count: usize,
-		encode_parameters: F,
+    /// Get a reference to the underlying [`SerialPort`].
+    pub fn stream(&self) -> &SerialPort {
+        &self.serial_port
+    }
+
+    /// Get a mutable reference to the underlying [`SerialPort`].
+    ///
+    /// Useful if you want to use or configure the serial port directly
+    pub fn stream_mut(&mut self) -> &mut SerialPort {
+        &mut self.serial_port
+    }
+
+    /// Write a raw instruction to a stream, and read a single raw response.
+    ///
+    /// This function also checks that the packet ID of the status response matches the one from the instruction.
+    ///
+    /// This is not suitable for broadcast instructions.
+    /// For broadcast instructions, each motor sends an individual response or no response is send at all.
+    /// Instead, use [`Self::write_instruction`] and [`Self::read_status_response`].
+    pub fn transfer_single<F>(
+        &mut self,
+        packet_id: u8,
+        instruction_id: u8,
+        parameter_count: usize,
+        encode_parameters: F,
 	) -> Result<StatusPacket<'_>, TransferError>
 	where
 		F: FnOnce(&mut [u8]),

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -127,6 +127,14 @@ where
 		&mut self.serial_port
 	}
 
+	/// Consume this bus object to get the serial port.
+	///
+	/// This discards any data in internal the read buffer of this bus object.
+	/// This is normally not a problem, since all data in the read buffer is also discarded when transmitting a new command.
+	pub fn into_serial_port(self) -> SerialPort {
+		self.serial_port
+	}
+
 	/// Write a raw instruction to a stream, and read a single raw response.
 	///
 	/// This function also checks that the packet ID of the status response matches the one from the instruction.

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -20,13 +20,44 @@ where
 	/// This function panics if the same motor ID is used for more than one write.
 	///
 	/// This function also panics if the data length for a motor exceeds the capacity of a `u16`.
-	pub fn bulk_write<Write, T>(&mut self, writes: &[Write]) -> Result<(), WriteError>
+	///
+	/// # Example
+	/// ```no_run
+	/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+	/// use dynamixel2::Bus;
+	/// use dynamixel2::instructions::BulkWriteData;
+	/// use std::time::Duration;
+	///
+	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600, Duration::from_millis(20))?;
+	/// bus.bulk_write(&[
+	///   // Write a u32 value of 2000 to register 116 of motor 1.
+	///   BulkWriteData {
+	///     motor_id: 1,
+	///     address: 116,
+	///     data: 2000u32.to_le_bytes().as_slice(),
+	///   },
+	///   // Write a u16 value of 300 to register 102 of motor 2.
+	///   BulkWriteData {
+	///     motor_id: 2,
+	///     address: 102,
+	///     data: 300u16.to_le_bytes().as_slice(),
+	///   },
+	/// ])?;
+	/// # Ok(())
+	/// # }
+	/// ```
+	pub fn bulk_write<'a, I, T>(&mut self, writes: &'a I) -> Result<(), WriteError>
 	where
-		Write: std::borrow::Borrow<BulkWriteData<T>>,
+		&'a I: IntoIterator,
+		<&'a I as IntoIterator>::IntoIter: Clone,
+		<&'a I as IntoIterator>::Item: std::borrow::Borrow<BulkWriteData<T>>,
 		T: AsRef<[u8]>,
 	{
+		use std::borrow::Borrow;
+
+		let writes = writes.into_iter();
 		let mut parameter_count = 0;
-		for write in writes {
+		for write in writes.clone() {
 			let write = write.borrow();
 			let data = write.data.as_ref();
 			if data.len() > u16::MAX.into() {

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -86,3 +86,87 @@ where
 		})
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Ensure that `bulk_write` accepts a slice of `BulkWriteData`.
+	///
+	/// This is a compile test. It only tests that the test code compiles.
+	#[allow(dead_code)]
+	fn bulk_write_accepts_slice(bus: &mut Bus<Vec<u8>, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {
+		bus.bulk_write(&[
+			BulkWriteData {
+				motor_id: 1,
+				address: 116,
+				data: 2000u32.to_le_bytes().as_slice(),
+			},
+			BulkWriteData {
+				motor_id: 2,
+				address: 102,
+				data: 300u16.to_le_bytes().as_slice(),
+			},
+		])?;
+		Ok(())
+	}
+
+	/// Ensure that `bulk_write` accepts a reference to a Vec of `BulkWriteData`.
+	///
+	/// This is a compile test. It only tests that the test code compiles.
+	#[allow(dead_code)]
+	fn bulk_write_accepts_vec_ref(bus: &mut Bus<Vec<u8>, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {
+		bus.bulk_write(&vec![
+			BulkWriteData {
+				motor_id: 1,
+				address: 116,
+				data: 2000u32.to_le_bytes().as_slice(),
+			},
+			BulkWriteData {
+				motor_id: 2,
+				address: 102,
+				data: 300u16.to_le_bytes().as_slice(),
+			},
+		])?;
+		Ok(())
+	}
+
+	/// Ensure that `bulk_write` accepts a reference to a Vec and doesn't clone the data in the vector.
+	///
+	/// This is a compile test. It only tests that the test code compiles.
+	#[allow(dead_code)]
+	fn bulk_write_accepts_vec_ref_no_clone(bus: &mut Bus<Vec<u8>, Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {
+		/// Non-clonable wrapper around `&[u8]` to ensure `bulk_write` doesn't clone data from vec references.
+		struct Data<'a> {
+			data: &'a [u8],
+		}
+
+		impl AsRef<[u8]> for Data<'_> {
+			fn as_ref(&self) -> &[u8] {
+				self.data
+			}
+		}
+
+		impl<'a> Data<'a> {
+			fn new<const N: usize>(data: &'a [u8; N]) -> Self {
+				Self {
+					data: data.as_slice(),
+				}
+			}
+		}
+
+		bus.bulk_write(&vec![
+			BulkWriteData {
+				motor_id: 1,
+				address: 116,
+				data: Data::new(&2000u32.to_le_bytes()),
+			},
+			BulkWriteData {
+				motor_id: 2,
+				address: 102,
+				data: Data::new(&300u16.to_le_bytes()),
+			},
+		])?;
+		Ok(())
+	}
+}

--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -15,6 +15,29 @@ where
 	/// # Panics
 	/// The amount of data to write for each motor must be exactly `count` bytes.
 	/// This function panics if that is not the case.
+	///
+	/// # Example
+	/// ```no_run
+	/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+	/// use dynamixel2::Bus;
+	/// use dynamixel2::instructions::SyncWriteData;
+	/// use std::time::Duration;
+	///
+	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600, Duration::from_millis(20))?;
+	/// // Write to register 116 of motor 1 and and 2 at the same time.
+	/// bus.sync_write(116, 4, &[
+	///   SyncWriteData {
+	///     motor_id: 1,
+	///     data: 2000u32.to_le_bytes(),
+	///   },
+	///   SyncWriteData {
+	///     motor_id: 2,
+	///     data: 1600u32.to_le_bytes(),
+	///   },
+	/// ])?;
+	/// # Ok(())
+	/// # }
+	/// ```
 	pub fn sync_write<'a, Iter, Data, Buf>(&mut self, address: u16, count: u16, data: Iter) -> Result<(), WriteError>
 	where
 		Iter: IntoIterator<Item = Data>,


### PR DESCRIPTION
Another week another pull request :small_airplane: 

Couple of things that I needed to change:

### Add getters for the internal `SerialPort`
Useful if you want to use or configure the serial port directly (such as using the SerialPort's `set_read_timeout` fn)
I have more thoughts about this but don't have the time rn
### use `AsRef` for the data in `SyncWriteData`
 If you have to provide the data as `&'a [u8]`but have it stored in as a `Vec<u8>` you have to call as ref on it:
 
which leads to this mess (sync_write_pos: Vec<SyncWriteData<Vec<u8>>)
 ```
  self.bus
      .sync_write(
          reg.address,
          reg.length,
          sync_write_pos
              .iter()
              .map(|d| SyncWriteData {
                  motor_id: d.motor_id,
                  data: d.data.as_ref(),
              })
              .collect::<Vec<_>>(),
      )
```

changing the signature to include `AsRef` leads to cleaner user code:
```
self.bus.sync_write(reg.address, reg.length, data)
```

A quick look at BulkWriteData shows that the data is already typed: `AsRef` but implementation doesn't use iterators. I could update the `bulk_write` fn to use iterators. Making both the function impls similar
