### PR TITLE
Automatically calculate proper read timeout for instructions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,15 @@
 # Unreleased
 - [minor][add] Allow direct access to the underlying serial port.
+- [minor][add] Allow changing the baud rate of the underlying serial port.
+- [minor][add] Automatically calculate the correct read timeout for instructions.
 - [minor][add] Add a `rs4xx` feature that enables the `rs4xx` support in the `serial2` crate.
+- [minor][fix] Set the read timeout of the underlying serial port to avoid blocking longer than intended.
 - [major][change] Change `bulk_write()` to take an iterator instead of a slice.
 - [major][change] Change `sync_read()` to accept any buffer type that implements `AsRef<[u8]>`.
+- [major][change] Remove the `read_timeout` parameter from `Bus` constructors.
+- [major][change] `Bus::new()` and `Buf::with_buffers()` can now return a `InitializeError` if it fails to determine the baud rate of the serial port.
+- [major][change] `Bus::read_status_response()` now takes the expected number of parameters to automatically calculate the read timeout.
+- [major][change] Replace the `PingResponse` struct with `Response<Ping>`.
 
 # Version 0.8.0 - 2024-04-15
 - [major][change] Remove `ReadBuffer` and `WriteBuffer` generic arguments from `StatusPacket`.

--- a/dynamixel2-cli/src/bin/dynamixel2/options.rs
+++ b/dynamixel2-cli/src/bin/dynamixel2/options.rs
@@ -22,7 +22,7 @@ pub struct Options {
 	/// The baud rate for the serial port.
 	#[clap(long, short)]
 	#[clap(global = true)]
-	#[clap(default_value = "9600")]
+	#[clap(default_value = "57600")]
 	pub baud_rate: u32,
 
 	#[clap(subcommand)]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -578,6 +578,17 @@ mod test {
 		assert!(message_transfer_time(4_000_000_000, 10) == Duration::from_secs(4_000_000_000));
 		assert!(message_transfer_time(4_000_000_000, 1) == Duration::from_secs(40_000_000_000));
 
+		assert!(message_transfer_time(43, 1) == Duration::from_secs(430));
+		assert!(message_transfer_time(43, 10) == Duration::from_secs(43));
+		assert!(message_transfer_time(43, 2) == Duration::from_secs(215));
+		assert!(message_transfer_time(43, 20) == Duration::from_millis(21_500));
+		assert!(message_transfer_time(43, 200) == Duration::from_millis(2_150));
+		assert!(message_transfer_time(43, 2_000_000) == Duration::from_micros(215));
+		assert!(message_transfer_time(43, 2_000_000_000) == Duration::from_nanos(215));
+		assert!(message_transfer_time(43, 4_000_000_000) == Duration::from_nanos(108)); // rounded up
+		assert!(message_transfer_time(3, 4_000_000_000) == Duration::from_nanos(8)); // rounded up
+		assert!(message_transfer_time(5, 4_000_000_000) == Duration::from_nanos(13)); // rounded up
+
 		let lots = u32::MAX - 1; // Use MAX - 1 because MAX is not cleanly divisible by 2.
 		assert!(message_transfer_time(lots, 1) == Duration::from_secs(u64::from(lots) * 10));
 		assert!(message_transfer_time(lots, lots) == Duration::from_secs(10));

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -16,8 +16,8 @@ pub struct Bus<ReadBuffer, WriteBuffer> {
 	/// The underlying stream (normally a serial port).
 	serial_port: SerialPort,
 
-	/// The timeout for reading a single response.
-	read_timeout: Duration,
+	/// The baud rate of the serial port, if known.
+	baud_rate: u32,
 
 	/// The buffer for reading incoming messages.
 	read_buffer: ReadBuffer,
@@ -56,7 +56,7 @@ impl<ReadBuffer, WriteBuffer> std::fmt::Debug for Bus<ReadBuffer, WriteBuffer> {
 
 		f.debug_struct("Bus")
 			.field("serial_port", &raw)
-			.field("read_timeout", &self.read_timeout)
+			.field("baud_rate", &self.baud_rate)
 			.finish_non_exhaustive()
 	}
 }
@@ -66,17 +66,20 @@ impl Bus<Vec<u8>, Vec<u8>> {
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
-	pub fn open(path: impl AsRef<Path>, baud_rate: u32, read_timeout: Duration) -> std::io::Result<Self> {
+	pub fn open(path: impl AsRef<Path>, baud_rate: u32) -> std::io::Result<Self> {
 		let port = SerialPort::open(path, baud_rate)?;
-		Ok(Self::new(port, read_timeout))
+		Ok(Self::with_buffers_and_baud_rate(port, vec![0; 128], vec![0; 128], baud_rate))
 	}
 
 	/// Create a new bus for an open serial port.
 	///
+	/// The serial port must already be configured in raw mode with the correct baud rate,
+	/// character size (8), parity (disabled) and stop bits (1).
+	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::with_buffers()`] if you want to use a custom buffers.
-	pub fn new(stream: SerialPort, read_timeout: Duration) -> Self {
-		Self::with_buffers(stream, read_timeout, vec![0; 128], vec![0; 128])
+	pub fn new(serial_port: SerialPort) -> Result<Self, crate::InitializeError> {
+		Self::with_buffers(serial_port, vec![0; 128], vec![0; 128])
 	}
 }
 
@@ -91,23 +94,36 @@ where
 	pub fn open_with_buffers(
 		path: impl AsRef<Path>,
 		baud_rate: u32,
-		read_timeout: Duration,
 		read_buffer: ReadBuffer,
 		write_buffer: WriteBuffer,
 	) -> std::io::Result<Self> {
 		let port = SerialPort::open(path, baud_rate)?;
-		Ok(Self::with_buffers(port, read_timeout, read_buffer, write_buffer))
+		Ok(Self::with_buffers_and_baud_rate(port, read_buffer, write_buffer, baud_rate))
 	}
 
 	/// Create a new bus using pre-allocated buffers.
-	pub fn with_buffers(serial_port: SerialPort, read_timeout: Duration, read_buffer: ReadBuffer, mut write_buffer: WriteBuffer) -> Self {
+	///
+	/// The serial port must already be configured in raw mode with the correct baud rate,
+	/// character size (8), parity (disabled) and stop bits (1).
+	pub fn with_buffers(serial_port: SerialPort, read_buffer: ReadBuffer, write_buffer: WriteBuffer) -> Result<Self, crate::InitializeError> {
+		let baud_rate = serial_port.get_configuration()
+			.map_err(crate::InitializeError::GetConfiguration)?
+			.get_baud_rate()
+			.map_err(crate::InitializeError::GetBaudRate)?;
+
+		Ok(Self::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate))
+	}
+
+	/// Create a new bus using pre-allocated buffers.
+	fn with_buffers_and_baud_rate(serial_port: SerialPort, read_buffer: ReadBuffer, mut write_buffer: WriteBuffer, baud_rate: u32) -> Self {
 		// Pre-fill write buffer with the header prefix.
+		// TODO: return Err instead of panicing.
 		assert!(write_buffer.as_mut().len() >= HEADER_SIZE + 2);
 		write_buffer.as_mut()[..4].copy_from_slice(&HEADER_PREFIX);
 
 		Self {
 			serial_port,
-			read_timeout,
+			baud_rate,
 			read_buffer,
 			read_len: 0,
 			used_bytes: 0,
@@ -125,24 +141,26 @@ where
 		&self.serial_port
 	}
 
-	/// Get a mutable reference to the underlying [`SerialPort`].
-	///
-	/// Useful if you want to use or configure the serial port directly
-	///
-	/// Note that performing any read or write with the [`SerialPort`] bypasses the read/write buffer of the bus,
-	/// and may disrupt the communication with the motors.
-	/// In general, it should be safe to read and write to the bus manually in between instructions,
-	/// if the response from the motors has already been received.
-	pub fn serial_port_mut(&mut self) -> &mut SerialPort {
-		&mut self.serial_port
-	}
-
 	/// Consume this bus object to get ownership of the serial port.
 	///
 	/// This discards any data in internal the read buffer of the bus object.
 	/// This is normally not a problem, since all data in the read buffer is also discarded when transmitting a new command.
 	pub fn into_serial_port(self) -> SerialPort {
 		self.serial_port
+	}
+
+	/// Get the baud rate of the bus.
+	pub fn baud_rate(&self) -> u32 {
+		self.baud_rate
+	}
+
+	/// Set the baud rate of the underlying serial port.
+	pub fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), std::io::Error> {
+		let mut settings = self.serial_port.get_configuration()?;
+		settings.set_baud_rate(baud_rate)?;
+		self.serial_port.set_configuration(&settings)?;
+		self.baud_rate = baud_rate;
+		Ok(())
 	}
 
 	/// Write a raw instruction to a stream, and read a single raw response.
@@ -157,13 +175,14 @@ where
 		packet_id: u8,
 		instruction_id: u8,
 		parameter_count: usize,
+		expected_response_parameters: u16,
 		encode_parameters: F,
 	) -> Result<StatusPacket<'_>, TransferError>
 	where
 		F: FnOnce(&mut [u8]),
 	{
 		self.write_instruction(packet_id, instruction_id, parameter_count, encode_parameters)?;
-		let response = self.read_status_response()?;
+		let response = self.read_status_response(expected_response_parameters)?;
 		crate::error::InvalidPacketId::check(response.packet_id(), packet_id).map_err(crate::ReadError::from)?;
 		Ok(response)
 	}
@@ -216,12 +235,11 @@ where
 		Ok(())
 	}
 
-	/// Read a raw status response from the bus.
-	pub fn read_status_response(&mut self) -> Result<StatusPacket, ReadError> {
+	/// Read a raw status response from the bus with the given deadline.
+	pub fn read_status_response_deadline(&mut self, deadline: Instant) -> Result<StatusPacket, ReadError> {
 		// Check that the read buffer is large enough to hold atleast a status packet header.
 		crate::error::BufferTooSmallError::check(STATUS_HEADER_SIZE, self.read_buffer.as_mut().len())?;
 
-		let deadline = Instant::now() + self.read_timeout;
 		let stuffed_message_len = loop {
 			self.remove_garbage();
 
@@ -241,15 +259,19 @@ where
 				}
 			}
 
-			if Instant::now() > deadline {
-				trace!(
-					"timeout reading status response, data in buffer: {:02X?}",
-					&self.read_buffer.as_ref()[..self.read_len]
-				);
-				return Err(std::io::ErrorKind::TimedOut.into());
-			}
+			let timeout = match deadline.checked_duration_since(Instant::now()) {
+				Some(x) => x,
+				None => {
+					trace!(
+						"timeout reading status response, data in buffer: {:02X?}",
+						&self.read_buffer.as_ref()[..self.read_len]
+					);
+					return Err(std::io::ErrorKind::TimedOut.into());
+				},
+			};
 
 			// Try to read more data into the buffer.
+			self.serial_port.set_read_timeout(timeout).ok();
 			let new_data = self.serial_port.read(&mut self.read_buffer.as_mut()[self.read_len..])?;
 			if new_data == 0 {
 				continue;
@@ -288,6 +310,28 @@ where
 		crate::MotorError::check(response.error())?;
 		Ok(response)
 	}
+
+	/// Read a raw status response with an automatically calculated timeout.
+	///
+	/// The read timeout is determined by the expected number of response parameters and the baud rate of the bus.
+	pub fn read_status_response(&mut self, expected_parameters: u16) -> Result<StatusPacket, ReadError> {
+		// Offical SDK adds a flat 34 milliseconds, so lets just mimick that.
+		let message_size = STATUS_HEADER_SIZE as u32 + u32::from(expected_parameters) + 2;
+		let timeout = message_transfer_time(message_size, self.baud_rate) + Duration::from_millis(34);
+		self.read_status_response_deadline(Instant::now() + timeout)
+	}
+}
+
+/// Calculate the required time to transfer a message of a given size.
+///
+/// The size must include any headers and footers of the message.
+pub(crate) fn message_transfer_time(message_size: u32, baud_rate: u32) -> Duration {
+	let baud_rate = u64::from(baud_rate);
+	let bits = u64::from(message_size) * 10; // each byte is 1 start bit, 8 data bits and 1 stop bit.
+	let secs = bits / baud_rate;
+	let subsec_bits = bits % baud_rate;
+	let nanos = (subsec_bits * 1_000_000_000).div_ceil(baud_rate);
+	Duration::new(secs, nanos as u32)
 }
 
 impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer>
@@ -502,5 +546,42 @@ mod test {
 
 		assert!(find_header(&[0xFF, 1]) == 2);
 		assert!(find_header(&[0, 1, 2, 3, 4, 0xFF, 6]) == 7);
+	}
+
+	#[test]
+	fn test_message_transfer_time() {
+		// Try a bunch of values to ensure we dealt with overflow correctly.
+		assert!(message_transfer_time(100, 1_000) == Duration::from_secs(1));
+		assert!(message_transfer_time(1_000, 10_000) == Duration::from_secs(1));
+		assert!(message_transfer_time(1_000, 1_000_000) == Duration::from_millis(10));
+		assert!(message_transfer_time(1_000, 10_000_000) == Duration::from_millis(1));
+		assert!(message_transfer_time(1_000, 100_000_000) == Duration::from_micros(100));
+		assert!(message_transfer_time(1_000, 1_000_000_000) == Duration::from_micros(10));
+		assert!(message_transfer_time(1_000, 2_000_000_000) == Duration::from_micros(5));
+		assert!(message_transfer_time(1_000, 4_000_000_000) == Duration::from_nanos(2500));
+		assert!(message_transfer_time(10_000, 4_000_000_000) == Duration::from_micros(25));
+		assert!(message_transfer_time(1_000_000, 4_000_000_000) == Duration::from_micros(2500));
+		assert!(message_transfer_time(10_000_000, 4_000_000_000) == Duration::from_millis(25));
+		assert!(message_transfer_time(100_000_000, 4_000_000_000) == Duration::from_millis(250));
+		assert!(message_transfer_time(1_000_000_000, 4_000_000_000) == Duration::from_millis(2500));
+		assert!(message_transfer_time(2_000_000_000, 4_000_000_000) == Duration::from_secs(5));
+		assert!(message_transfer_time(4_000_000_000, 4_000_000_000) == Duration::from_secs(10));
+		assert!(message_transfer_time(4_000_000_000, 2_000_000_000) == Duration::from_secs(20));
+		assert!(message_transfer_time(4_000_000_000, 1_000_000_000) == Duration::from_secs(40));
+		assert!(message_transfer_time(4_000_000_000, 100_000_000) == Duration::from_secs(400));
+		assert!(message_transfer_time(4_000_000_000, 10_000_000) == Duration::from_secs(4_000));
+		assert!(message_transfer_time(4_000_000_000, 1_000_000) == Duration::from_secs(40_000));
+		assert!(message_transfer_time(4_000_000_000, 100_000) == Duration::from_secs(400_000));
+		assert!(message_transfer_time(4_000_000_000, 10_000) == Duration::from_secs(4_000_000));
+		assert!(message_transfer_time(4_000_000_000, 1_000) == Duration::from_secs(40_000_000));
+		assert!(message_transfer_time(4_000_000_000, 100) == Duration::from_secs(400_000_000));
+		assert!(message_transfer_time(4_000_000_000, 10) == Duration::from_secs(4_000_000_000));
+		assert!(message_transfer_time(4_000_000_000, 1) == Duration::from_secs(40_000_000_000));
+
+		let lots = u32::MAX - 1; // Use MAX - 1 because MAX is not cleanly divisible by 2.
+		assert!(message_transfer_time(lots, 1) == Duration::from_secs(u64::from(lots) * 10));
+		assert!(message_transfer_time(lots, lots) == Duration::from_secs(10));
+		assert!(message_transfer_time(lots / 2, lots) == Duration::from_secs(5));
+		assert!(message_transfer_time(lots, lots / 2) == Duration::from_secs(20));
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,15 @@
 use crate::instructions::packet_id::BROADCAST;
 
+/// An error that can occur while initializing a bus.
+#[derive(Debug)]
+pub enum InitializeError {
+	/// Failed to get the configuration of the serial port.
+	GetConfiguration(std::io::Error),
+
+	/// Failed to get the baud rate from the configuration of the serial port.
+	GetBaudRate(std::io::Error),
+}
+
 /// An error that can occur during a read/write transfer.
 #[derive(Debug)]
 pub enum TransferError {
@@ -172,6 +182,7 @@ pub struct InvalidParameterCount {
 }
 
 impl BufferTooSmallError {
+	/// Check if a buffer is large enough for the required total size.
 	pub fn check(required_size: usize, total_size: usize) -> Result<(), Self> {
 		if required_size <= total_size {
 			Ok(())
@@ -423,6 +434,15 @@ impl From<InvalidInstruction> for InvalidMessage {
 impl From<InvalidParameterCount> for InvalidMessage {
 	fn from(other: InvalidParameterCount) -> Self {
 		Self::InvalidParameterCount(other)
+	}
+}
+
+impl std::fmt::Display for InitializeError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::GetConfiguration(e) => write!(f, "failed to get configuration of serial port: {e}"),
+			Self::GetBaudRate(e) => write!(f, "failed to get baud rate of serial port: {e}"),
+		}
 	}
 }
 

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -48,7 +48,7 @@ where
 		})?;
 		for read in reads {
 			let read = read.as_ref();
-			let response = self.read_status_response().and_then(|response| {
+			let response = self.read_status_response(read.count).and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), read.motor_id)?;
 				crate::InvalidParameterCount::check(response.parameters().len(), read.count.into())?;
 				Ok(response)

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -28,7 +28,7 @@ where
 	/// use dynamixel2::instructions::BulkWriteData;
 	/// use std::time::Duration;
 	///
-	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600, Duration::from_millis(20))?;
+	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600)?;
 	/// bus.bulk_write(&[
 	///   // Write a u32 value of 2000 to register 116 of motor 1.
 	///   BulkWriteData {

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -39,7 +39,7 @@ mod sync_write;
 mod write;
 
 pub use factory_reset::FactoryResetKind;
-pub use ping::PingResponse;
+pub use ping::Ping;
 
 /// Data from or for a specific motor.
 ///
@@ -120,6 +120,6 @@ where
 			data: (),
 		})
 	} else {
-		Ok(bus.read_status_response()?.try_into()?)
+		Ok(bus.read_status_response(0)?.try_into()?)
 	}
 }

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -9,7 +9,7 @@ where
 {
 	/// Read an arbitrary number of bytes from multiple motors.
 	fn read_raw(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_>, TransferError> {
-		let response = self.transfer_single(motor_id, instruction_id::READ, 4, |buffer| {
+		let response = self.transfer_single(motor_id, instruction_id::READ, 4, count, |buffer| {
 			write_u16_le(&mut buffer[0..], address);
 			write_u16_le(&mut buffer[2..], count);
 		})?;

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -21,7 +21,7 @@ where
 			buffer[4..].copy_from_slice(motor_ids);
 		})?;
 		for &motor_id in motor_ids {
-			let response = self.read_status_response().and_then(|response| {
+			let response = self.read_status_response(count).and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
 				crate::InvalidParameterCount::check(response.parameters().len(), count.into())?;
 				Ok(response)
@@ -46,11 +46,11 @@ where
 		let count = 1;
 		self.write_instruction(packet_id::BROADCAST, instruction_id::SYNC_READ, 4 + motor_ids.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
-			write_u16_le(&mut buffer[2..], count as u16);
+			write_u16_le(&mut buffer[2..], count);
 			buffer[4..].copy_from_slice(motor_ids);
 		})?;
 		for &motor_id in motor_ids {
-			let data = self.read_status_response().and_then(|response| {
+			let data = self.read_status_response(count).and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
 				Ok(response.try_into()?)
 			});
@@ -70,11 +70,11 @@ where
 		let count = 2;
 		self.write_instruction(packet_id::BROADCAST, instruction_id::SYNC_READ, 4 + motor_ids.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
-			write_u16_le(&mut buffer[2..], count as u16);
+			write_u16_le(&mut buffer[2..], count);
 			buffer[4..].copy_from_slice(motor_ids);
 		})?;
 		for &motor_id in motor_ids {
-			let data = self.read_status_response().and_then(|response| {
+			let data = self.read_status_response(count).and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
 				Ok(response.try_into()?)
 			});
@@ -94,13 +94,13 @@ where
 		let count = 4;
 		self.write_instruction(packet_id::BROADCAST, instruction_id::SYNC_READ, 4 + motor_ids.len(), |buffer| {
 			write_u16_le(&mut buffer[0..], address);
-			write_u16_le(&mut buffer[2..], count as u16);
+			write_u16_le(&mut buffer[2..], count);
 			buffer[4..].copy_from_slice(motor_ids);
 		})?;
 		for &motor_id in motor_ids {
-			let data = self.read_status_response().and_then(|response| {
+			let data = self.read_status_response(count).and_then(|response| {
 				crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
-				crate::InvalidParameterCount::check(response.parameters().len(), count)?;
+				crate::InvalidParameterCount::check(response.parameters().len(), count.into())?;
 				Ok(response.try_into()?)
 			});
 			on_response(data);

--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -23,7 +23,7 @@ where
 	/// use dynamixel2::instructions::SyncWriteData;
 	/// use std::time::Duration;
 	///
-	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600, Duration::from_millis(20))?;
+	/// let mut bus = Bus::open("/dev/ttyUSB0", 57600)?;
 	/// // Write to register 116 of motor 1 and and 2 at the same time.
 	/// bus.sync_write(116, 4, &[
 	///   SyncWriteData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,25 +28,15 @@ mod log;
 pub mod checksum;
 pub mod instructions;
 
-mod bus;
 mod bytestuff;
 mod endian;
+
+mod bus;
+pub use bus::*;
+
 mod error;
+pub use error::*;
 
-pub use error::ExpectedCount;
-pub use error::InvalidChecksum;
-pub use error::InvalidHeaderPrefix;
-pub use error::InvalidInstruction;
-pub use error::InvalidMessage;
-pub use error::InvalidPacketId;
-pub use error::InvalidParameterCount;
-pub use error::MotorError;
-pub use error::ReadError;
-pub use error::TransferError;
-pub use error::WriteError;
-
-pub use bus::Bus;
-pub use bus::Response;
 
 /// Re-exported `serial2` crate in case you need to modify serial port settings.
 pub use serial2;


### PR DESCRIPTION
This PR removes the manually provided `read_timeout` parameter, and instead uses the baud rate of the serial port and the message length to compute the expected response time.

The timing is based on the fact that each byte going over the serial line takes 1 start bit, 8 data bits and 1 stop bit.

The downside is that we now need to query the serial port for the baud rate in `Bus::new()` and `Bus::with_buffers()`, so they can return an error.

@omelia-iliffe: As part of this PR I removed `serial_port_mut()` again. It would allow to change the baud rate of the port, which makes the timeout computation inaccurate. Do you think there is an important enough use case for mutable access to the serial port that we should support it? Note that you don't need mutable access to read/write, only to configure the port.