### PR TITLE
Naming and design tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.8"
 [features]
 default = ["std", "serial2"]
 alloc = []
-std = []
+std = ["alloc"]
 rs4xx = ["serial2/rs4xx"]
 
 [workspace]

--- a/dynamixel2-cli/src/bin/dynamixel2/main.rs
+++ b/dynamixel2-cli/src/bin/dynamixel2/main.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
-use dynamixel2::transport::serial2::Serial2Port;
+use dynamixel2::serial2::SerialPort;
 
 mod logging;
 mod options;
@@ -152,7 +152,7 @@ fn do_main(options: Options) -> Result<(), ()> {
 	Ok(())
 }
 
-fn open_bus(options: &Options) -> Result<dynamixel2::Bus<Vec<u8>, Vec<u8>, Serial2Port>, ()> {
+fn open_bus(options: &Options) -> Result<dynamixel2::Bus<Vec<u8>, Vec<u8>, SerialPort>, ()> {
 	let bus = dynamixel2::Bus::open(&options.serial_port, options.baud_rate)
 		.map_err(|e| log::error!("Failed to open serial port: {}: {}", options.serial_port.display(), e))?;
 	log::debug!(

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -30,7 +30,7 @@ where
 }
 
 #[cfg(feature = "serial2")]
-impl Bus<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
+impl Bus<Vec<u8>, Vec<u8>, serial2::SerialPort> {
 	/// Open a serial port with the given baud rate.
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
@@ -55,7 +55,7 @@ impl Bus<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
 }
 
 #[cfg(feature = "serial2")]
-impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer, crate::transport::serial2::Serial2Port>
+impl<ReadBuffer, WriteBuffer> Bus<ReadBuffer, WriteBuffer, serial2::SerialPort>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -48,7 +48,7 @@ impl Bus<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::with_buffers()`] if you want to use a custom buffers.
-	pub fn new(serial_port: serial2::SerialPort) -> Result<Self, crate::InitializeError<std::io::Error>> {
+	pub fn new(serial_port: serial2::SerialPort) -> std::io::Result<Self> {
 		let messenger = Messenger::with_buffers(serial_port, vec![0; 128], vec![0; 128])?;
 		Ok(Self { messenger })
 	}
@@ -89,7 +89,7 @@ where
 		transport: T,
 		read_buffer: ReadBuffer,
 		write_buffer: WriteBuffer,
-	) -> Result<Self, crate::InitializeError<T::Error>> {
+	) -> Result<Self, T::Error> {
 		let messenger = Messenger::with_buffers(transport, read_buffer, write_buffer)?;
 		Ok(Self { messenger })
 	}

--- a/src/device.rs
+++ b/src/device.rs
@@ -25,7 +25,7 @@ where
 }
 
 #[cfg(feature = "serial2")]
-impl Device<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
+impl Device<Vec<u8>, Vec<u8>, serial2::SerialPort> {
 	/// Open a serial port with the given baud rate.
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
@@ -50,7 +50,7 @@ impl Device<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
 }
 
 #[cfg(feature = "serial2")]
-impl<ReadBuffer, WriteBuffer> Device<ReadBuffer, WriteBuffer, crate::transport::serial2::Serial2Port>
+impl<ReadBuffer, WriteBuffer> Device<ReadBuffer, WriteBuffer, serial2::SerialPort>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,

--- a/src/device.rs
+++ b/src/device.rs
@@ -43,7 +43,7 @@ impl Device<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port> {
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::with_buffers()`] if you want to use a custom buffers.
-	pub fn new(serial_port: serial2::SerialPort) -> Result<Self, crate::InitializeError<std::io::Error>> {
+	pub fn new(serial_port: serial2::SerialPort) -> std::io::Result<Self> {
 		let messenger = Messenger::with_buffers(serial_port, vec![0; 128], vec![0; 128])?;
 		Ok(Self { messenger })
 	}
@@ -80,7 +80,7 @@ where
 		transport: impl Into<T>,
 		read_buffer: ReadBuffer,
 		write_buffer: WriteBuffer,
-	) -> Result<Self, crate::InitializeError<T::Error>> {
+	) -> Result<Self, T::Error> {
 		let messenger = Messenger::with_buffers(transport, read_buffer, write_buffer)?;
 		Ok(Device { messenger })
 	}

--- a/src/device.rs
+++ b/src/device.rs
@@ -77,7 +77,7 @@ where
 {
 	/// Create a new device using pre-allocated buffers.
 	pub fn with_buffers(
-		serial_port: impl Into<T>,
+		serial_port: T,
 		read_buffer: ReadBuffer,
 		write_buffer: WriteBuffer,
 	) -> Result<Self, T::Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,9 +56,6 @@ pub enum ReadError<E> {
 	/// Failed to read from the serial port.
 	Io(E),
 
-	/// A timeout occurred while waiting for a response.
-	Timeout,
-
 	/// The received message is invalid.
 	InvalidMessage(InvalidMessage),
 
@@ -521,7 +518,6 @@ where
 				e.required_size, e.total_size
 			),
 			Self::Io(e) => write!(f, "failed to read from serial port: {}", e),
-			Self::Timeout => write!(f, "timeout while waiting for response"),
 			Self::InvalidMessage(e) => write!(f, "{}", e),
 			Self::MotorError(e) => write!(f, "{}", e),
 		}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,6 @@
 use crate::instructions::packet_id::BROADCAST;
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-/// An error that can occur while initializing a bus.
-#[derive(Debug)]
-pub enum InitializeError<E> {
-	/// Failed to get the configuration of the serial port.
-	GetConfiguration(E),
-
-	/// Failed to get the baud rate from the configuration of the serial port.
-	GetBaudRate(E),
-}
-
 /// An error that can occur during a read/write transfer.
 #[derive(Debug)]
 pub enum TransferError<E> {
@@ -299,8 +289,6 @@ impl InvalidParameterCount {
 }
 
 #[cfg(feature = "std")]
-impl<E: Debug + Display> std::error::Error for InitializeError<E> {}
-#[cfg(feature = "std")]
 impl<E: Debug + Display> std::error::Error for TransferError<E> {}
 #[cfg(feature = "std")]
 impl<E: Debug + Display> std::error::Error for WriteError<E> {}
@@ -452,18 +440,6 @@ impl From<InvalidInstruction> for InvalidMessage {
 impl From<InvalidParameterCount> for InvalidMessage {
 	fn from(other: InvalidParameterCount) -> Self {
 		Self::InvalidParameterCount(other)
-	}
-}
-
-impl<E> Display for InitializeError<E>
-where
-	E: Display,
-{
-	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		match self {
-			Self::GetConfiguration(e) => write!(f, "failed to get configuration of serial port: {e}"),
-			Self::GetBaudRate(e) => write!(f, "failed to get baud rate of serial port: {e}"),
-		}
 	}
 }
 

--- a/src/instructions/action.rs
+++ b/src/instructions/action.rs
@@ -1,12 +1,12 @@
 use super::{instruction_id, packet_id};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, Response, TransferError, WriteError};
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Send an action command to trigger a previously registered instruction.
 	///

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -1,6 +1,6 @@
 use super::{instruction_id, packet_id, BulkReadData};
 use crate::endian::{write_u16_le, write_u8_le};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, ReadError, Response, WriteError};
 
 #[cfg(feature = "alloc")]
@@ -11,7 +11,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Synchronously read arbitrary data ranges from multiple motors in one command.
 	///

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -1,13 +1,13 @@
 use super::{instruction_id, packet_id, BulkWriteData};
 use crate::endian::{write_u16_le, write_u8_le};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, WriteError};
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Synchronously write arbitrary data ranges to multiple motors.
 	///

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -93,7 +93,7 @@ where
 mod tests {
 	use super::*;
 
-	type Bus = crate::Bus<Vec<u8>, Vec<u8>, crate::transport::serial2::Serial2Port>;
+	type Bus = crate::Bus<Vec<u8>, Vec<u8>, serial2::SerialPort>;
 
 	/// Ensure that `bulk_write` accepts a slice of `BulkWriteData`.
 	///

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -1,5 +1,5 @@
 use super::{instruction_id, packet_id};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, Response, TransferError, WriteError};
 
 /// The parameters for the CLEAR command to clear the revolution counter.
@@ -9,7 +9,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Clear the multi-revolution counter of a motor.
 	///

--- a/src/instructions/factory_reset.rs
+++ b/src/instructions/factory_reset.rs
@@ -1,5 +1,5 @@
 use super::{instruction_id, packet_id};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, Response, TransferError, WriteError};
 
 /// The kind of factory reset to perform.
@@ -20,7 +20,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Reset the settings of a motor to the factory defaults.
 	///

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -38,7 +38,7 @@ mod sync_read;
 mod sync_write;
 mod write;
 
-use crate::Transport;
+use crate::SerialPort;
 pub use factory_reset::FactoryResetKind;
 pub use ping::Ping;
 
@@ -113,7 +113,7 @@ fn read_response_if_not_broadcast<ReadBuffer, WriteBuffer, T>(
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	if motor_id == packet_id::BROADCAST {
 		Ok(crate::Response {

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -89,11 +89,13 @@ where
 					let response = response.try_into()?;
 					on_response(response);
 				},
-				Err(ReadError::Timeout) => {
+				Err(ReadError::Io(e)) if T::is_timeout_error(&e) => {
 					trace!("Ping response timed out.");
 					return Ok(());
 				},
-				Err(e) => return Err(e.into()),
+				Err(e) => {
+					return Err(e.into());
+				}
 			}
 		}
 	}

--- a/src/instructions/ping.rs
+++ b/src/instructions/ping.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 use super::{instruction_id, packet_id};
 use crate::bus::StatusPacket;
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, ReadError, Response, TransferError};
 
 use crate::packet::Packet;
@@ -42,7 +42,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Ping a specific motor by ID.
 	///

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -1,6 +1,6 @@
 use super::instruction_id;
 use crate::endian::write_u16_le;
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{bus::StatusPacket, Bus, Response, TransferError};
 
 use crate::packet::Packet;
@@ -11,7 +11,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Read an arbitrary number of bytes from multiple motors.
 	fn read_raw(&mut self, motor_id: u8, address: u16, count: u16) -> Result<StatusPacket<'_>, TransferError<T::Error>> {

--- a/src/instructions/reboot.rs
+++ b/src/instructions/reboot.rs
@@ -1,12 +1,12 @@
 use super::{instruction_id, packet_id};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, Response, TransferError, WriteError};
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Send a reboot command to a specific motor.
 	///

--- a/src/instructions/reg_write.rs
+++ b/src/instructions/reg_write.rs
@@ -2,13 +2,13 @@ use super::{instruction_id, read_response_if_not_broadcast};
 use crate::{Bus, Response, TransferError};
 
 use crate::endian::{write_u16_le, write_u32_le};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Register a write of an arbitrary number of bytes, to be triggered later by an `action` command.
 	///

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -1,6 +1,6 @@
 use super::{instruction_id, packet_id};
 use crate::endian::write_u16_le;
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, ReadError, Response, WriteError};
 
 use crate::packet::Packet;
@@ -11,7 +11,7 @@ impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Synchronously read an arbitrary number of bytes from multiple motors in one command.
 	///

--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -1,13 +1,13 @@
 use super::{instruction_id, packet_id, SyncWriteData};
 use crate::endian::{write_u16_le, write_u32_le};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, WriteError};
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Synchronously write an arbitrary number of bytes to multiple motors.
 	///

--- a/src/instructions/write.rs
+++ b/src/instructions/write.rs
@@ -1,13 +1,13 @@
 use super::{instruction_id, read_response_if_not_broadcast};
 use crate::endian::{write_u16_le, write_u32_le};
-use crate::transport::Transport;
+use crate::serial_port::SerialPort;
 use crate::{Bus, Response, TransferError};
 
 impl<ReadBuffer, WriteBuffer, T> Bus<ReadBuffer, WriteBuffer, T>
 where
 	ReadBuffer: AsRef<[u8]> + AsMut<[u8]>,
 	WriteBuffer: AsRef<[u8]> + AsMut<[u8]>,
-	T: Transport,
+	T: SerialPort,
 {
 	/// Write an arbitrary number of bytes to a specific motor.
 	///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "serial2")]
+/// Public re-export of the serial2 crate.
+pub use serial2;
+
 #[macro_use]
 mod log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,20 +36,21 @@ mod log;
 pub mod checksum;
 pub mod instructions;
 
-mod bytestuff;
-mod endian;
-
 mod bus;
 pub use bus::*;
 
 mod device;
-mod error;
-pub mod transport;
 pub use device::*;
+
+mod serial_port;
+pub use serial_port::SerialPort;
+
+mod error;
+pub use error::*;
+
 mod packet;
 pub use packet::Packet;
+
+mod bytestuff;
+mod endian;
 mod messaging;
-
-pub use transport::Transport;
-
-pub use error::*;

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -168,7 +168,8 @@ where
 			}
 
 			// Try to read more data into the buffer.
-			let new_data = self.transport.read(&mut self.read_buffer.as_mut()[self.read_len..], &deadline)?;
+			let new_data = self.transport.read(&mut self.read_buffer.as_mut()[self.read_len..], &deadline)
+				.map_err(ReadError::Io)?;
 			if new_data == 0 {
 				continue;
 			}

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -145,7 +145,7 @@ where
 		// Check that the read buffer is large enough to hold atleast a status packet header.
 		crate::error::BufferTooSmallError::check(P::HEADER_SIZE, self.read_buffer.as_mut().len())?;
 
-		self.transport.set_timeout(timeout).map_err(ReadError::Io)?;
+		let deadline = self.transport.make_deadline(timeout);
 
 		let stuffed_message_len = loop {
 			self.remove_garbage();
@@ -168,7 +168,7 @@ where
 			}
 
 			// Try to read more data into the buffer.
-			let new_data = self.transport.read(&mut self.read_buffer.as_mut()[self.read_len..])?;
+			let new_data = self.transport.read(&mut self.read_buffer.as_mut()[self.read_len..], &deadline)?;
 			if new_data == 0 {
 				continue;
 			}

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -38,7 +38,7 @@ where
 		transport: impl Into<T>,
 		read_buffer: ReadBuffer,
 		write_buffer: WriteBuffer,
-	) -> Result<Self, crate::InitializeError<T::Error>> {
+	) -> Result<Self, T::Error> {
 		let transport = transport.into();
 		let baud_rate = transport.baud_rate()?;
 		Ok(Self::with_buffers_and_baud_rate(transport, read_buffer, write_buffer, baud_rate))

--- a/src/serial_port/mod.rs
+++ b/src/serial_port/mod.rs
@@ -1,33 +1,33 @@
-//! The [`Transport`] trait is used to implementing the Dynamixel Protocol 2.0 communication interface.
+//! [`SerialPort`] trait to support reading/writing from different serial port implementations.
 
 use core::time::Duration;
 
 #[cfg(feature = "serial2")]
 pub mod serial2;
 
-/// [`Transport`]s are used to communicate with the hardware via reading and writing data.
+/// [`SerialPort`]s are used to communicate with the hardware by reading and writing data.
 ///
 /// The implementor of the trait must also configure the serial line to use 8 bits characters, 1 stop bit, no parity and no flow control.
-pub trait Transport {
-	/// The error type returned by the transport when reading, writing or setting the baud rate.
+pub trait SerialPort {
+	/// The error type returned by the serial port when reading, writing or setting the baud rate.
 	type Error;
 
 	/// A point in time that can be used as a deadline for a I/O operations.
 	type Instant;
 
-	/// Get the current baud rate of the transport.
+	/// Get the current baud rate of the serial port.
 	fn baud_rate(&self) -> Result<u32, Self::Error>;
 
-	/// Set the baud rate of the transport.
+	/// Set the baud rate of the serial port.
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error>;
 
-	/// Discard the input buffer of the transport. Maybe a no-op on some platforms.
+	/// Discard the input buffer of the serial port. Maybe a no-op on some platforms.
 	fn discard_input_buffer(&mut self) -> Result<(), Self::Error>;
 
 	/// Returns available bytes to read, blocking until at least one byte is available or the deadline expires.
 	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, Self::Error>;
 
-	/// Write all bytes in the buffer to the transport.
+	/// Write all bytes in the buffer to the serial port.
 	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error>;
 
 	/// Make a deadline to expire after the given timeout.

--- a/src/serial_port/serial2.rs
+++ b/src/serial_port/serial2.rs
@@ -1,8 +1,8 @@
-//! Serial port transport implementation using the `serial2` crate.
+//! Trait implementation using the `serial2` crate.
 
 use std::time::{Duration, Instant};
 
-impl crate::Transport for serial2::SerialPort {
+impl crate::SerialPort for serial2::SerialPort {
 	type Error = std::io::Error;
 
 	type Instant = std::time::Instant;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,20 +7,30 @@ use crate::ReadError;
 use core::time::Duration;
 
 /// [`Transport`]s are used to communicate with the hardware via reading and writing data.
-/// The Dynamixel Protocol 2.0 uses 8 bits char size, 1 stop bit, no parity.
+///
+/// The implementor of the trait must also configure the serial line to use 8 bits characters, 1 stop bit, no parity and no flow control.
 pub trait Transport {
 	/// The error type returned by the transport when reading, writing or setting the baud rate.
 	type Error;
+
+	/// A point in time that can be used as a deadline for a I/O operations.
+	type Instant;
+
 	/// Get the current baud rate of the transport.
 	fn baud_rate(&self) -> Result<u32, crate::InitializeError<Self::Error>>;
+
 	/// Set the baud rate of the transport.
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error>;
+
 	/// Discard the input buffer of the transport. Maybe a no-op on some platforms.
 	fn discard_input_buffer(&mut self) -> Result<(), Self::Error>;
-	/// Sets the timeout deadline and starts a timer. After the timeout duration elapses, the `[Self::read`] method will return with a timeout error.
-	fn set_timeout(&mut self, timeout: Duration) -> Result<(), Self::Error>;
-	/// Returns available bytes to read, blocking until at least one byte is available or the timeout duration elapses. The timeout must be set prior to calling with [`Self::set_timeout`].
-	fn read(&mut self, buffer: &mut [u8]) -> Result<usize, ReadError<Self::Error>>;
+
+	/// Returns available bytes to read, blocking until at least one byte is available or the deadline expires.
+	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, ReadError<Self::Error>>;
+
 	/// Write all bytes in the buffer to the transport.
 	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error>;
+
+	/// Make a deadline to expire after the given timeout.
+	fn make_deadline(&self, timeout: Duration) -> Self::Instant;
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,10 +1,9 @@
 //! The [`Transport`] trait is used to implementing the Dynamixel Protocol 2.0 communication interface.
 
+use core::time::Duration;
+
 #[cfg(feature = "serial2")]
 pub mod serial2;
-
-use crate::ReadError;
-use core::time::Duration;
 
 /// [`Transport`]s are used to communicate with the hardware via reading and writing data.
 ///
@@ -26,11 +25,14 @@ pub trait Transport {
 	fn discard_input_buffer(&mut self) -> Result<(), Self::Error>;
 
 	/// Returns available bytes to read, blocking until at least one byte is available or the deadline expires.
-	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, ReadError<Self::Error>>;
+	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, Self::Error>;
 
 	/// Write all bytes in the buffer to the transport.
 	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error>;
 
 	/// Make a deadline to expire after the given timeout.
 	fn make_deadline(&self, timeout: Duration) -> Self::Instant;
+
+	/// Check if an error indicates a timeout.
+	fn is_timeout_error(error: &Self::Error) -> bool;
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,7 +16,7 @@ pub trait Transport {
 	type Instant;
 
 	/// Get the current baud rate of the transport.
-	fn baud_rate(&self) -> Result<u32, crate::InitializeError<Self::Error>>;
+	fn baud_rate(&self) -> Result<u32, Self::Error>;
 
 	/// Set the baud rate of the transport.
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error>;

--- a/src/transport/serial2.rs
+++ b/src/transport/serial2.rs
@@ -2,85 +2,36 @@
 
 use std::time::{Duration, Instant};
 
-/// Re-exported `serial2` crate in case you need to modify serial port settings.
-pub use serial2;
-
-/// A wrapper around a `serial2::SerialPort` that implements the `Transport` trait.
-pub struct Serial2Port {
-	/// The serial port.
-	pub port: serial2::SerialPort,
-}
-
-impl Serial2Port {
-	/// Create a new `Serial2Port` from a `serial2::SerialPort`.
-	pub fn new(port: serial2::SerialPort) -> Self {
-		Self {
-			port,
-		}
-	}
-}
-
-impl From<serial2::SerialPort> for Serial2Port {
-	fn from(port: serial2::SerialPort) -> Self {
-		Self::new(port)
-	}
-}
-
-impl core::fmt::Debug for Serial2Port {
-	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
-		#[derive(Debug)]
-		#[allow(dead_code)] // Dead code analysis ignores derive debug impls, but that is the whole point of this struct.
-		enum Raw {
-			#[cfg(unix)]
-			Fd(std::os::unix::io::RawFd),
-			#[cfg(windows)]
-			Handle(std::os::windows::io::RawHandle),
-		}
-
-		#[cfg(unix)]
-		let raw = {
-			use std::os::unix::io::AsRawFd;
-			Raw::Fd(self.port.as_raw_fd())
-		};
-		#[cfg(windows)]
-		let raw = {
-			use std::os::windows::io::AsRawHandle;
-			Raw::Handle(self.port.as_raw_handle())
-		};
-		write!(f, "SerialPort({:?})", raw)
-	}
-}
-
-impl crate::Transport for Serial2Port {
+impl crate::Transport for serial2::SerialPort {
 	type Error = std::io::Error;
 
 	type Instant = std::time::Instant;
 
 	fn baud_rate(&self) -> Result<u32, Self::Error> {
-		self.port.get_configuration()?
+		self.get_configuration()?
 			.get_baud_rate()
 	}
 
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error> {
-		let mut settings = self.port.get_configuration()?;
+		let mut settings = self.get_configuration()?;
 		settings.set_baud_rate(baud_rate)?;
-		self.port.set_configuration(&settings)?;
+		self.set_configuration(&settings)?;
 		Ok(())
 	}
 
 	fn discard_input_buffer(&mut self) -> Result<(), Self::Error> {
-		self.port.discard_input_buffer()
+		serial2::SerialPort::discard_input_buffer(self)
 	}
 
 	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, Self::Error> {
 		let timeout = deadline.checked_duration_since(Instant::now())
 			.ok_or(std::io::ErrorKind::TimedOut)?;
-		self.port.set_read_timeout(timeout)?;
-		self.port.read(buffer)
+		self.set_read_timeout(timeout)?;
+		serial2::SerialPort::read(self, buffer)
 	}
 
 	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-		self.port.write_all(buffer)
+		serial2::SerialPort::write_all(self, buffer)
 	}
 
 	fn make_deadline(&self, timeout: Duration) -> Self::Instant {

--- a/src/transport/serial2.rs
+++ b/src/transport/serial2.rs
@@ -56,11 +56,9 @@ impl crate::Transport for Serial2Port {
 
 	type Instant = std::time::Instant;
 
-	fn baud_rate(&self) -> Result<u32, crate::InitializeError<Self::Error>> {
-		self.port.get_configuration()
-			.map_err(crate::InitializeError::GetConfiguration)?
+	fn baud_rate(&self) -> Result<u32, Self::Error> {
+		self.port.get_configuration()?
 			.get_baud_rate()
-			.map_err(crate::InitializeError::GetBaudRate)
 	}
 
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error> {

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -1,5 +1,5 @@
 use assert2::{assert, let_assert};
-use dynamixel2::{Bus, Device, Instructions, ReadError, Transport};
+use dynamixel2::{Bus, Device, Instructions, ReadError, SerialPort};
 use log::{info, trace};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -8,18 +8,18 @@ use std::thread;
 use std::time::Duration;
 use test_log::test;
 
-mod mock_transport;
-use crate::mock_transport::MockSerialPort;
+mod mock_serial_port;
+use crate::mock_serial_port::MockSerialPort;
 
 type ReadBuffer = Vec<u8>;
 type WriteBuffer = Vec<u8>;
 type T = MockSerialPort;
 fn setup_bus() -> (Bus<ReadBuffer, WriteBuffer, T>, Device<ReadBuffer, WriteBuffer, T>) {
-	let transport = MockSerialPort::new(56700);
-	let device_transport = transport.device_port();
+	let serial_port = MockSerialPort::new(56700);
+	let device_serial_port = serial_port.device_port();
 	(
-		Bus::with_buffers(transport, vec![0; 1024], vec![0; 1024]).unwrap(),
-		Device::with_buffers(device_transport, vec![0; 1024], vec![0; 1024]).unwrap(),
+		Bus::with_buffers(serial_port, vec![0; 1024], vec![0; 1024]).unwrap(),
+		Device::with_buffers(device_serial_port, vec![0; 1024], vec![0; 1024]).unwrap(),
 	)
 }
 

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -74,7 +74,7 @@ fn test_packet_response() {
 				let res = device.read(Duration::from_secs(1));
 				let packet = match res {
 					Ok(p) => p,
-					Err(ReadError::Timeout) => continue,
+					Err(ReadError::Io(e)) if T::is_timeout_error(&e) => continue,
 					Err(e) => {
 						return Err(e.into());
 					},

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -1,14 +1,15 @@
-mod mock_transport;
-
-use crate::mock_transport::MockSerialPort;
-use dynamixel2::{Bus, Device, Instructions, ReadError, TransferError, Transport};
+use assert2::{assert, let_assert};
+use dynamixel2::{Bus, Device, Instructions, ReadError, Transport};
 use log::{info, trace};
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use test_log::test;
+
+mod mock_transport;
+use crate::mock_transport::MockSerialPort;
 
 type ReadBuffer = Vec<u8>;
 type WriteBuffer = Vec<u8>;
@@ -61,24 +62,21 @@ fn test_packet_response() {
 	let kill_device = Arc::new(AtomicBool::new(false));
 	let (mut bus, mut device) = setup_bus();
 	let bus_t = thread::spawn(move || {
-		bus.write_u8(1, 5, 1)?;
-		let res = bus.read_u8(1, 5)?;
-		assert_eq!(res.data, 1);
-		Ok::<(), TransferError<<MockSerialPort as Transport>::Error>>(())
+		assert!(let Ok(_) = bus.write_u8(1, 5, 1));
+		let_assert!(Ok(response) =  bus.read_u8(1, 5));
+		assert!(response.data == 1);
 	});
 	let device_t = thread::spawn({
 		let kill_device = kill_device.clone();
 		move || {
 			let mut control_table = ControlTable::new(10);
 			while !kill_device.load(Relaxed) {
-				let res = device.read(Duration::from_secs(1));
-				let packet = match res {
-					Ok(p) => p,
+				let packet = device.read(Duration::from_millis(50));
+				let packet = match packet {
 					Err(ReadError::Io(e)) if T::is_timeout_error(&e) => continue,
-					Err(e) => {
-						return Err(e.into());
-					},
+					x => x,
 				};
+				let_assert!(Ok(packet) = packet);
 				let id = packet.id;
 				if id != DEVICE_ID {
 					continue;
@@ -87,28 +85,26 @@ fn test_packet_response() {
 					Instructions::Ping => {},
 					Instructions::Read { address, length } => {
 						if let Some(data) = control_table.read(address, length) {
-							device.write_status(DEVICE_ID, 0, length as usize, |buffer| {
+							assert!(let Ok(()) = device.write_status(DEVICE_ID, 0, length as usize, |buffer| {
 								buffer.copy_from_slice(data);
-							})?;
+							}));
 						} else {
-							device.write_status_error(DEVICE_ID, 0x07)?;
+							assert!(let Ok(()) = device.write_status_error(DEVICE_ID, 0x07));
 						}
 					},
 					Instructions::Write { address, parameters } => {
 						if control_table.write(address, parameters) {
-							device.write_status_ok(DEVICE_ID)?;
+							let_assert!(Ok(()) = device.write_status_ok(DEVICE_ID));
 						} else {
-							device.write_status_error(DEVICE_ID, 0x07)?;
+							let_assert!(Ok(()) = device.write_status_error(DEVICE_ID, 0x07));
 						}
 					},
 					i => todo!("impl {:?}", i),
 				}
 			}
-
-			Ok::<(), TransferError<<MockSerialPort as Transport>::Error>>(())
 		}
 	});
-	bus_t.join().unwrap().unwrap();
+	bus_t.join().unwrap();
 	kill_device.store(true, Relaxed);
-	device_t.join().unwrap().unwrap();
+	device_t.join().unwrap();
 }

--- a/tests/mock_serial_port.rs
+++ b/tests/mock_serial_port.rs
@@ -1,4 +1,4 @@
-use dynamixel2::Transport;
+use dynamixel2::SerialPort;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -28,7 +28,7 @@ impl MockSerialPort {
 	}
 }
 
-impl Transport for MockSerialPort {
+impl SerialPort for MockSerialPort {
 	type Error = std::io::Error;
 
 	type Instant = std::time::Instant;

--- a/tests/mock_transport.rs
+++ b/tests/mock_transport.rs
@@ -1,13 +1,13 @@
-use dynamixel2::{InitializeError, ReadError, Transport};
+use dynamixel2::Transport;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
 #[derive(Default, Clone)]
 pub struct MockSerialPort {
 	pub read_buffer: Arc<Mutex<VecDeque<u8>>>,
 	pub write_buffer: Arc<Mutex<VecDeque<u8>>>,
 	pub baud_rate: u32,
-	pub deadline: Option<Instant>,
 }
 
 impl MockSerialPort {
@@ -16,7 +16,6 @@ impl MockSerialPort {
 			read_buffer: Arc::new(Mutex::new(VecDeque::new())),
 			write_buffer: Arc::new(Mutex::new(VecDeque::new())),
 			baud_rate,
-			deadline: None,
 		}
 	}
 
@@ -25,34 +24,33 @@ impl MockSerialPort {
 			read_buffer: self.write_buffer.clone(),
 			write_buffer: self.read_buffer.clone(),
 			baud_rate: self.baud_rate,
-			deadline: self.deadline,
 		}
 	}
 }
 
 impl Transport for MockSerialPort {
-	type Error = ();
+	type Error = std::io::Error;
 
 	type Instant = std::time::Instant;
 
-	fn baud_rate(&self) -> Result<u32, InitializeError<()>> {
+	fn baud_rate(&self) -> Result<u32, InitializeError<Self::Error>> {
 		Ok(self.baud_rate)
 	}
 
-	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), ()> {
+	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error> {
 		self.baud_rate = baud_rate;
 		Ok(())
 	}
 
-	fn discard_input_buffer(&mut self) -> Result<(), ()> {
+	fn discard_input_buffer(&mut self) -> Result<(), Self::Error> {
 		self.read_buffer.lock().unwrap().clear();
 		Ok(())
 	}
 
-	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, ReadError<Self::Error>> {
+	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, Self::Error> {
 		let mut data = loop {
 			if Instant::now() > *deadline {
-				return Err(ReadError::Timeout);
+				return Err(std::io::ErrorKind::TimedOut.into());
 			}
 			if let Ok(data) = self.read_buffer.try_lock() {
 				break data;
@@ -63,7 +61,7 @@ impl Transport for MockSerialPort {
 		Ok(len)
 	}
 
-	fn write_all(&mut self, buffer: &[u8]) -> Result<(), ()> {
+	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
 		let mut data = self.write_buffer.lock().unwrap();
 		for &byte in buffer {
 			data.push_back(byte);
@@ -73,5 +71,9 @@ impl Transport for MockSerialPort {
 
 	fn make_deadline(&self, timeout: Duration) -> Self::Instant {
 		Instant::now() + timeout
+	}
+
+	fn is_timeout_error(error: &Self::Error) -> bool {
+		error.kind() == std::io::ErrorKind::TimedOut
 	}
 }

--- a/tests/mock_transport.rs
+++ b/tests/mock_transport.rs
@@ -33,7 +33,7 @@ impl Transport for MockSerialPort {
 
 	type Instant = std::time::Instant;
 
-	fn baud_rate(&self) -> Result<u32, InitializeError<Self::Error>> {
+	fn baud_rate(&self) -> Result<u32, Self::Error> {
 		Ok(self.baud_rate)
 	}
 


### PR DESCRIPTION
Global overview:
* Although I liked the idea of not exposing too much time details in the trait, having a stateful timeout requires the `Transport` implementation to always store the deadline. This means that you basically always need a wrapper type to implement the `Transport` trait.

  So instead I made the timeout non-stateful so we can implement the trait directly for `serial2::SerialPort`.
  
  This also opened the way for renaming the trait to `SerialPort` again.
* I didn't want the `SerialPort` impls to return `dynamixel2` errors, but only their own error. So I removed the `Timeout` error variant and instead added a static `is_timeout_error()` function to the `SerialPort` trait. Similarly I removed the `InitializeError` and just have the functions return `SerialPort::Error`.

So far, these are the high level changes. I also want to rename `Bus`, `Device` and `Messenger`, but I'm out of time for today :p

@omelia-iliffe: Could you look over the changes and see what you think?