### PR TITLE
Apply fmt and clippy

### DIFF
--- a/dynamixel2-cli/src/bin/dynamixel2/main.rs
+++ b/dynamixel2-cli/src/bin/dynamixel2/main.rs
@@ -101,11 +101,7 @@ fn do_main(options: Options) -> Result<(), ()> {
 			if response.alert {
 				log::warn!("Alert bit set in response from motor!")
 			}
-			log::info!(
-				"{:?}: {:?}",
-				start.elapsed(),
-				response.data,
-			);
+			log::info!("{:?}: {:?}", start.elapsed(), response.data,);
 		},
 		Command::Write8 { motor_id, address, value } => {
 			let mut client = open_client(&options)?;
@@ -164,12 +160,7 @@ fn do_main(options: Options) -> Result<(), ()> {
 		},
 		Command::Write { motor_id, address, data } => {
 			let mut client = open_client(&options)?;
-			log::debug!(
-				"Writing {} bytes to motor {} at address {}",
-				data.len(),
-				motor_id.raw(),
-				address
-			);
+			log::debug!("Writing {} bytes to motor {} at address {}", data.len(), motor_id.raw(), address);
 			let start = Instant::now();
 			let response = client
 				.write_bytes(motor_id.raw(), *address, &data)

--- a/src/bus/data.rs
+++ b/src/bus/data.rs
@@ -1,6 +1,6 @@
-use core::mem::MaybeUninit;
 use crate::bus::StatusPacket;
 use crate::Response;
+use core::mem::MaybeUninit;
 
 /// A fixed-size type that can be read or written over the bus.
 pub trait Data: Sized {
@@ -130,9 +130,7 @@ impl<T: Sized, const N: usize> ArrayInitializer<T, N> {
 	pub unsafe fn push(&mut self, value: T) {
 		debug_assert!(self.initialized < N);
 		// SAFETY: The caller must ensure `push` is called at most N times.
-		let slot = unsafe {
-			self.data.get_unchecked_mut(self.initialized)
-		};
+		let slot = unsafe { self.data.get_unchecked_mut(self.initialized) };
 		slot.write(value);
 		self.initialized += 1;
 	}

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -424,14 +424,14 @@ mod test {
 	fn test_static_buffer() {
 		let buffer1 = static_buffer!(128);
 		assert!(buffer1.len() == 128);
-		for e in buffer1 {
-			assert!(*e == 0);
+		for i in 0..buffer1.len() {
+			assert!(buffer1[i] == 0, "i: {i}");
 		}
 
 		let buffer2 = static_buffer!(64);
 		assert!(buffer2.len() == 64);
-		for e in buffer2 {
-			assert!(*e == 0);
+		for i in 0..buffer2.len() {
+			assert!(buffer2[i] == 0, "i: {i}");
 		}
 	}
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -424,14 +424,14 @@ mod test {
 	fn test_static_buffer() {
 		let buffer1 = static_buffer!(128);
 		assert!(buffer1.len() == 128);
-		for i in 0..buffer1.len() {
-			assert!(buffer1[i] == 0);
+		for e in buffer1 {
+			assert!(*e == 0);
 		}
 
 		let buffer2 = static_buffer!(64);
 		assert!(buffer2.len() == 64);
-		for i in 0..buffer2.len() {
-			assert!(buffer2[i] == 0);
+		for e in buffer2 {
+			assert!(*e == 0);
 		}
 	}
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -309,15 +309,13 @@ impl std::error::Error for InvalidInstruction {}
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidParameterCount {}
 
-impl<E> From<WriteError<E>> for TransferError<E>
-{
+impl<E> From<WriteError<E>> for TransferError<E> {
 	fn from(other: WriteError<E>) -> Self {
 		Self::WriteError(other)
 	}
 }
 
-impl<E> From<ReadError<E>> for TransferError<E>
-{
+impl<E> From<ReadError<E>> for TransferError<E> {
 	fn from(other: ReadError<E>) -> Self {
 		Self::ReadError(other)
 	}
@@ -556,11 +554,7 @@ impl Display for InvalidPacketId {
 
 impl Display for InvalidInstruction {
 	fn fmt(&self, f: &mut Formatter) -> FmtResult {
-		write!(
-			f,
-			"invalid instruction ID, expected {:?}, got {:?}",
-			self.expected, self.actual
-		)
+		write!(f, "invalid instruction ID, expected {:?}, got {:?}", self.expected, self.actual)
 	}
 }
 

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -63,8 +63,8 @@ where
 ///
 /// # Panic
 /// Panics if multiple read operation use the same motor ID.
-fn write_bulk_read_instruction<'a, SerialPort, Buffer>(
-	client: &'a mut Client<SerialPort, Buffer>,
+fn write_bulk_read_instruction<SerialPort, Buffer>(
+	client: &mut Client<SerialPort, Buffer>,
 	reads: &[BulkReadData],
 ) -> Result<(), WriteError<SerialPort::Error>>
 where

--- a/src/instructions/bulk_read.rs
+++ b/src/instructions/bulk_read.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
+use super::{instruction_id, packet_id, BulkReadData};
 use crate::bus::data::{decode_status_packet_bytes, decode_status_packet_bytes_borrow};
 use crate::bus::endian::{write_u16_le, write_u8_le};
 use crate::{Client, ReadError, Response, WriteError};
-use super::{instruction_id, packet_id, BulkReadData};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where
@@ -81,9 +81,9 @@ where
 			}
 		}
 	}
-    client.write_instruction(packet_id::BROADCAST, instruction_id::BULK_READ, 5 * reads.len(), |buffer| {
+	client.write_instruction(packet_id::BROADCAST, instruction_id::BULK_READ, 5 * reads.len(), |buffer| {
 		for (i, read) in reads.iter().enumerate() {
-			let buffer = &mut buffer[i*5..][..5];
+			let buffer = &mut buffer[i * 5..][..5];
 			write_u8_le(&mut buffer[0..], read.motor_id);
 			write_u16_le(&mut buffer[1..], read.address);
 			write_u16_le(&mut buffer[3..], read.count);
@@ -163,7 +163,7 @@ where
 	where
 		T: for<'b> From<&'b [u8]>,
 	{
-		let BulkReadData {motor_id, count, .. } = self.pop_bulk_read_data()?;
+		let BulkReadData { motor_id, count, .. } = self.pop_bulk_read_data()?;
 		Some(self.next_response(motor_id, count))
 	}
 
@@ -172,7 +172,7 @@ where
 	where
 		[u8]: core::borrow::Borrow<T>,
 	{
-		let BulkReadData {motor_id, count, .. } = self.pop_bulk_read_data()?;
+		let BulkReadData { motor_id, count, .. } = self.pop_bulk_read_data()?;
 		Some(self.next_response_borrow(motor_id, count))
 	}
 

--- a/src/instructions/bulk_write.rs
+++ b/src/instructions/bulk_write.rs
@@ -137,9 +137,7 @@ mod tests {
 	///
 	/// This is a compile test. It only tests that the test code compiles.
 	#[allow(dead_code)]
-	fn bulk_write_accepts_vec_ref_no_clone(
-		client: &mut Client,
-	) -> Result<(), Box<dyn std::error::Error>> {
+	fn bulk_write_accepts_vec_ref_no_clone(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
 		/// Non-clonable wrapper around `&[u8]` to ensure `bulk_write` doesn't clone data from vec references.
 		struct Data<'a> {
 			data: &'a [u8],

--- a/src/instructions/clear.rs
+++ b/src/instructions/clear.rs
@@ -25,7 +25,12 @@ where
 	///
 	/// If you want to broadcast this instruction, it may be more convenient to use [`Self::broadcast_clear_revolution_counter()`] instead.
 	pub fn clear_revolution_counter(&mut self, motor_id: u8) -> Result<Response<()>, TransferError<SerialPort::Error>> {
-		self.write_instruction(motor_id, instruction_id::CLEAR, CLEAR_REVOLUTION_COUNT.len(), clear_revolution_count_parameters)?;
+		self.write_instruction(
+			motor_id,
+			instruction_id::CLEAR,
+			CLEAR_REVOLUTION_COUNT.len(),
+			clear_revolution_count_parameters,
+		)?;
 		Ok(super::read_response_if_not_broadcast(self, motor_id)?)
 	}
 
@@ -53,14 +58,13 @@ where
 	pub fn clear_error(&mut self, motor_id: u8) -> Result<Response<()>, TransferError<SerialPort::Error>> {
 		self.write_instruction(motor_id, instruction_id::CLEAR, CLEAR_ERROR.len(), clear_error_parameters)?;
 		Ok(super::read_response_if_not_broadcast(self, motor_id)?)
-
 	}
 
 	/// Try to clear the error of all motors on the bus.
 	///
 	/// This will reset the "error code" register to 0 if the error can be cleared
 	/// and if the instruction is supported by the motor.
-    ///
+	///
 	/// This instruction is currently only implemented on the Dynamixel Y series.
 	pub fn broadcast_clear_error(&mut self) -> Result<(), WriteError<SerialPort::Error>> {
 		self.write_instruction(

--- a/src/instructions/read.rs
+++ b/src/instructions/read.rs
@@ -1,8 +1,8 @@
-use crate::bus::data::{decode_status_packet, decode_status_packet_bytes};
-use crate::bus::{Data, StatusPacket};
-use crate::bus::endian::write_u16_le;
-use crate::{Client, Response, TransferError};
 use super::instruction_id;
+use crate::bus::data::{decode_status_packet, decode_status_packet_bytes};
+use crate::bus::endian::write_u16_le;
+use crate::bus::{Data, StatusPacket};
+use crate::{Client, Response, TransferError};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where
@@ -25,7 +25,7 @@ where
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read_bytes<'a, T>(&'a mut self, motor_id: u8, address: u16, count: u16) -> Result<Response<T>, TransferError<SerialPort::Error>>
 	where
-		T: From<&'a [u8]>
+		T: From<&'a [u8]>,
 	{
 		let status = self.read_raw(motor_id, address, count)?;
 		Ok(decode_status_packet_bytes(status)?)
@@ -39,7 +39,7 @@ where
 	/// Use [`Self::sync_read`] to read from multiple motors with one command.
 	pub fn read<T>(&mut self, motor_id: u8, address: u16) -> Result<Response<T>, TransferError<SerialPort::Error>>
 	where
-	T: Data
+		T: Data,
 	{
 		let status = self.read_raw(motor_id, address, T::ENCODED_SIZE)?;
 		Ok(decode_status_packet(status)?)

--- a/src/instructions/reboot.rs
+++ b/src/instructions/reboot.rs
@@ -1,5 +1,5 @@
-use crate::{Client, Response, TransferError, WriteError};
 use super::{instruction_id, packet_id};
+use crate::{Client, Response, TransferError, WriteError};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where

--- a/src/instructions/reg_write.rs
+++ b/src/instructions/reg_write.rs
@@ -1,7 +1,7 @@
-use crate::bus::endian::write_u16_le;
-use crate::{Client, Response, TransferError};
-use crate::bus::Data;
 use super::{instruction_id, read_response_if_not_broadcast};
+use crate::bus::endian::write_u16_le;
+use crate::bus::Data;
+use crate::{Client, Response, TransferError};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -177,7 +177,7 @@ where
 	}
 
 	/// Read the next motor reply, borrowing the data from the internal read buffer.
-	pub fn read_next_borrow<'a>(&'a mut self) -> Option<Result<Response<&'a T>, ReadError<SerialPort::Error>>>
+	pub fn read_next_borrow(&mut self) -> Option<Result<Response<&T>, ReadError<SerialPort::Error>>>
 	where
 		[u8]: core::borrow::Borrow<T>,
 	{
@@ -203,7 +203,7 @@ where
 		Ok(decode_status_packet_bytes(response)?)
 	}
 
-	fn next_response_borrow<'a>(&'a mut self, motor_id: u8) -> Result<Response<&'a T>, ReadError<SerialPort::Error>>
+	fn next_response_borrow(&mut self, motor_id: u8) -> Result<Response<&T>, ReadError<SerialPort::Error>>
 	where
 		[u8]: core::borrow::Borrow<T>,
 	{
@@ -316,6 +316,6 @@ where
 		crate::InvalidPacketId::check(response.packet_id(), motor_id)?;
 		crate::InvalidParameterCount::check(response.parameters().len(), T::ENCODED_SIZE.into())?;
 
-		Ok(decode_status_packet(response)?)
+		decode_status_packet(response)
 	}
 }

--- a/src/instructions/sync_read.rs
+++ b/src/instructions/sync_read.rs
@@ -1,10 +1,10 @@
 use core::marker::PhantomData;
 
-use crate::bus::endian::write_u16_le;
-use crate::bus::data::{decode_status_packet, decode_status_packet_bytes, decode_status_packet_bytes_borrow};
-use crate::bus::data::Data;
-use crate::{Client, ReadError, Response, WriteError};
 use super::{instruction_id, packet_id};
+use crate::bus::data::Data;
+use crate::bus::data::{decode_status_packet, decode_status_packet_bytes, decode_status_packet_bytes_borrow};
+use crate::bus::endian::write_u16_le;
+use crate::{Client, ReadError, Response, WriteError};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where

--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -1,6 +1,6 @@
+use super::{instruction_id, packet_id, SyncWriteData};
 use crate::bus::endian::write_u16_le;
 use crate::{Client, WriteError};
-use super::{instruction_id, packet_id, SyncWriteData};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where
@@ -38,7 +38,12 @@ where
 	/// # Ok(())
 	/// # }
 	/// ```
-	pub fn sync_write_bytes<'a, Iter, Data, Buf>(&mut self, address: u16, count: u16, data: Iter) -> Result<(), WriteError<SerialPort::Error>>
+	pub fn sync_write_bytes<'a, Iter, Data, Buf>(
+		&mut self,
+		address: u16,
+		count: u16,
+		data: Iter,
+	) -> Result<(), WriteError<SerialPort::Error>>
 	where
 		Iter: IntoIterator<Item = Data>,
 		Iter::IntoIter: ExactSizeIterator,

--- a/src/instructions/write.rs
+++ b/src/instructions/write.rs
@@ -1,7 +1,7 @@
-use crate::bus::endian::write_u16_le;
-use crate::{Client, Response, TransferError};
-use crate::bus::Data;
 use super::{instruction_id, read_response_if_not_broadcast};
+use crate::bus::endian::write_u16_le;
+use crate::bus::Data;
+use crate::{Client, Response, TransferError};
 
 impl<SerialPort, Buffer> Client<SerialPort, Buffer>
 where

--- a/src/serial_port/serial2.rs
+++ b/src/serial_port/serial2.rs
@@ -4,12 +4,10 @@ use std::time::{Duration, Instant};
 
 impl crate::SerialPort for serial2::SerialPort {
 	type Error = std::io::Error;
-
 	type Instant = std::time::Instant;
 
 	fn baud_rate(&self) -> Result<u32, Self::Error> {
-		self.get_configuration()?
-			.get_baud_rate()
+		self.get_configuration()?.get_baud_rate()
 	}
 
 	fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), Self::Error> {
@@ -24,7 +22,8 @@ impl crate::SerialPort for serial2::SerialPort {
 	}
 
 	fn read(&mut self, buffer: &mut [u8], deadline: &Self::Instant) -> Result<usize, Self::Error> {
-		let timeout = deadline.checked_duration_since(Instant::now())
+		let timeout = deadline
+			.checked_duration_since(Instant::now())
 			.ok_or(std::io::ErrorKind::TimedOut)?;
 		self.set_read_timeout(timeout)?;
 		serial2::SerialPort::read(self, buffer)

--- a/tests/common/mock/mock_device.rs
+++ b/tests/common/mock/mock_device.rs
@@ -207,7 +207,7 @@ impl MockDevice {
 						Err(e) => {
 							error!("aborting sync/bulk read due to read error {e}");
 							return;
-						}
+						},
 					}
 				}
 			}

--- a/tests/common/mock/mock_serial_port.rs
+++ b/tests/common/mock/mock_serial_port.rs
@@ -9,9 +9,9 @@ pub struct SharedBuffer {
 }
 
 impl Default for SharedBuffer {
-    fn default() -> Self {
-        Self::new()
-    }
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 impl SharedBuffer {

--- a/tests/common/mock/mock_serial_port.rs
+++ b/tests/common/mock/mock_serial_port.rs
@@ -8,6 +8,12 @@ pub struct SharedBuffer {
 	buffer: Arc<Mutex<Vec<u8>>>,
 }
 
+impl Default for SharedBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SharedBuffer {
 	pub fn new() -> SharedBuffer {
 		SharedBuffer {

--- a/tests/common/mock/mock_serial_port.rs
+++ b/tests/common/mock/mock_serial_port.rs
@@ -1,7 +1,7 @@
-use std::sync::{Arc, Mutex, MutexGuard};
 use dynamixel2::SerialPort;
-use std::time::{Duration, Instant};
 use log::trace;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
 
 #[derive(Clone)]
 pub struct SharedBuffer {
@@ -50,7 +50,6 @@ impl MockSerial {
 
 impl SerialPort for MockSerial {
 	type Error = std::io::Error;
-
 	type Instant = std::time::Instant;
 
 	fn baud_rate(&self) -> Result<u32, Self::Error> {
@@ -73,7 +72,7 @@ impl SerialPort for MockSerial {
 			}
 			if let Some(mut data) = self.read_buffer.read() {
 				if data.is_empty() {
-					continue
+					continue;
 				}
 				let len = data.len();
 				if len > buffer.len() {
@@ -84,9 +83,9 @@ impl SerialPort for MockSerial {
 				if !buffer[..len].is_empty() {
 					trace!("{} read: {:?}", self.name, &buffer[..len]);
 				}
-				return Ok(len)
+				return Ok(len);
 			}
-		};
+		}
 	}
 
 	fn write_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
@@ -103,5 +102,4 @@ impl SerialPort for MockSerial {
 	fn is_timeout_error(error: &Self::Error) -> bool {
 		error.kind() == std::io::ErrorKind::TimedOut
 	}
-
 }

--- a/tests/common/mock/mod.rs
+++ b/tests/common/mock/mod.rs
@@ -1,42 +1,53 @@
-use std::sync::Arc;
+use dynamixel2::{Client, Device};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
-use dynamixel2::{Client, Device};
+use std::sync::Arc;
 mod mock_device;
 mod mock_serial_port;
 
 use mock_device::MockDevice;
 use mock_serial_port::MockSerial;
 pub fn new_client_device(device_ids: &[u8]) -> Result<(Client<MockSerial>, Vec<MockDevice>), std::io::Error> {
-    let mut client_serial = MockSerial::new("Client");
-    let device_ports: Vec<_> = device_ids.iter().map(|id| {
-        let mut serial = MockSerial::new(&format!("device {id}"));
-        client_serial.add_device(serial.read_buffer.clone());
-        serial.add_device(client_serial.read_buffer.clone());
-        (id, serial)
+	let mut client_serial = MockSerial::new("Client");
+	let device_ports: Vec<_> = device_ids
+		.iter()
+		.map(|id| {
+			let mut serial = MockSerial::new(&format!("device {id}"));
+			client_serial.add_device(serial.read_buffer.clone());
+			serial.add_device(client_serial.read_buffer.clone());
+			(id, serial)
+		})
+		.collect();
+	let device_ports_copy = device_ports.clone();
+	let devices = device_ports
+		.into_iter()
+		.map(|(id, mut d)| {
+			// to each MockSerial, connect the read buffers from the other MockSerials
+			device_ports_copy
+				.iter()
+				.filter(|(other_id, _)| id != *other_id)
+				.cloned()
+				.for_each(|(_, other)| {
+					d.add_device(other.read_buffer);
+				});
+			let device = Device::new(d).unwrap();
+			MockDevice::new(*id, device)
+		})
+		.collect();
+	let client = Client::new(client_serial)?;
 
-    }).collect();
-    let device_ports_copy = device_ports.clone();
-    let devices = device_ports.into_iter().map(|(id, mut d)| {
-        // to each MockSerial, connect the read buffers from the other MockSerials
-        device_ports_copy.iter().filter(|(other_id, _)| id != *other_id ).cloned().for_each(|(_, other)| {
-            d.add_device(other.read_buffer);
-        });
-        let device = Device::new(d).unwrap();
-        MockDevice::new(*id, device)
-    }).collect();
-    let client = Client::new(client_serial)?;
-
-    Ok((client, devices))
+	Ok((client, devices))
 }
 
-
-pub fn run_mock<F>(test: F) where F: FnOnce(&[u8], Client<MockSerial>) {
-    let device_ids = &[1, 2];
-    let kill_device = Arc::new(AtomicBool::new(false));
-    let (bus, devices) = new_client_device(device_ids).unwrap();
-    let device_t = devices.into_iter().map(|d| d.run(kill_device.clone())).collect::<Vec<_>>();
-    test(device_ids, bus);
-    kill_device.store(true, Relaxed);
-    device_t.into_iter().for_each(|d| d.join().unwrap());
+pub fn run_mock<F>(test: F)
+where
+	F: FnOnce(&[u8], Client<MockSerial>),
+{
+	let device_ids = &[1, 2];
+	let kill_device = Arc::new(AtomicBool::new(false));
+	let (bus, devices) = new_client_device(device_ids).unwrap();
+	let device_t = devices.into_iter().map(|d| d.run(kill_device.clone())).collect::<Vec<_>>();
+	test(device_ids, bus);
+	kill_device.store(true, Relaxed);
+	device_t.into_iter().for_each(|d| d.join().unwrap());
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
-pub mod real;
 pub mod mock;
+pub mod real;
 
 #[cfg(not(feature = "integration_test"))]
 pub use mock::run_mock as run;

--- a/tests/common/real.rs
+++ b/tests/common/real.rs
@@ -6,25 +6,25 @@ const DEFAULT_SERIAL_PATH: &str = "/dev/ttyUSB0";
 const DEFAULT_BAUD: u32 = 56_700;
 const DEFAULT_IDS: &[u8] = &[1, 2];
 pub fn run(test: impl FnOnce(&[u8], Client<serial2::SerialPort>)) {
-    // prevent multiple threads trying to use the serial port
-    let _lock = SERIAL_MUTEX.lock();
-    let path = std::env::var("SERIAL_PATH").unwrap_or(DEFAULT_SERIAL_PATH.to_string());
-    let baud = std::env::var("SERIAL_BAUD")
-        .map(|s| {
-            let_assert!(Ok(s) = s.parse(), "unable to parse SERIAL_BAUD {} into u32", s);
-            s
-        })
-        .unwrap_or(DEFAULT_BAUD);
-    let ids = std::env::var("DEVICE_IDS")
-        .map(|ids| {
-            ids.split(",")
-                .map(|id| {
-                    let_assert!(Ok(id) = id.parse(), "unable to parse DEVICE_IDS {} into Vec<u8>", ids);
-                    id
-                })
-                .collect()
-        })
-        .unwrap_or(DEFAULT_IDS.to_vec());
-    let_assert!(Ok(client) = Client::open(&path, baud), "unable to open serial port at {}", path);
-    test(&ids, client)
+	// prevent multiple threads trying to use the serial port
+	let _lock = SERIAL_MUTEX.lock();
+	let path = std::env::var("SERIAL_PATH").unwrap_or(DEFAULT_SERIAL_PATH.to_string());
+	let baud = std::env::var("SERIAL_BAUD")
+		.map(|s| {
+			let_assert!(Ok(s) = s.parse(), "unable to parse SERIAL_BAUD {} into u32", s);
+			s
+		})
+		.unwrap_or(DEFAULT_BAUD);
+	let ids = std::env::var("DEVICE_IDS")
+		.map(|ids| {
+			ids.split(",")
+				.map(|id| {
+					let_assert!(Ok(id) = id.parse(), "unable to parse DEVICE_IDS {} into Vec<u8>", ids);
+					id
+				})
+				.collect()
+		})
+		.unwrap_or(DEFAULT_IDS.to_vec());
+	let_assert!(Ok(client) = Client::open(&path, baud), "unable to open serial port at {}", path);
+	test(&ids, client)
 }


### PR DESCRIPTION
While running `cargo fmt` for another PR I noticed that the codebase is not formatted. Also, clippy had a few suggestions where explicit lifetime parameters could be dropped etc..