### PR TITLE
fix use of alloc feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ jobs:
        features:
          - --no-default-features
          - --no-default-features --features serial2,rs4xx
+         - --no-default-features --features alloc
          - --features log
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ alloc = []
 log = ["dep:log"]
 
 # Enable support for the `serial2` crate.
-serial2 = ["dep:serial2"]
+serial2 = ["dep:serial2", "std"]
 
 # Enable rs4xx support of the `serial2` crate.
 rs4xx = ["serial2?/rs4xx"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,4 @@
 use core::time::Duration;
-#[cfg(feature = "serial2")]
-use std::path::Path;
 
 use crate::bus::{Bus, StatusPacket};
 use crate::instructions::instruction_id;
@@ -53,7 +51,7 @@ impl Client<serial2::SerialPort, Vec<u8>> {
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
-	pub fn open(path: impl AsRef<Path>, baud_rate: u32) -> std::io::Result<Self> {
+	pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
 		let serial_port = serial2::SerialPort::open(path, baud_rate)?;
 		let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
 		Ok(Self { bus })
@@ -68,7 +66,7 @@ where
 	/// Open a serial port with the given baud rate.
 	///
 	/// This will allocate a new read and write buffer of 128 bytes each.
-	pub fn open_with_buffers(path: impl AsRef<Path>, baud_rate: u32, read_buffer: Buffer, write_buffer: Buffer) -> std::io::Result<Self> {
+	pub fn open_with_buffers(path: impl AsRef<std::path::Path>, baud_rate: u32, read_buffer: Buffer, write_buffer: Buffer) -> std::io::Result<Self> {
 		let serial_port = serial2::SerialPort::open(path, baud_rate)?;
 		let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
 		Ok(Self { bus })
@@ -76,7 +74,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<SerialPort> Client<SerialPort, Vec<u8>>
+impl<SerialPort> Client<SerialPort, alloc::vec::Vec<u8>>
 where
 	SerialPort: crate::SerialPort,
 {
@@ -89,7 +87,7 @@ where
 	/// Use [`Self::with_buffers()`] if you want to use a custom buffers.
 	#[cfg(feature = "alloc")]
 	pub fn new(serial_port: SerialPort) -> Result<Self, SerialPort::Error> {
-		let bus = Bus::with_buffers(serial_port, vec![0; 128], vec![0; 128])?;
+		let bus = Bus::with_buffers(serial_port, alloc::vec![0; 128], alloc::vec![0; 128])?;
 		Ok(Self { bus })
 	}
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,6 +4,9 @@ use crate::instructions::instruction_id;
 use crate::{InvalidParameterCount, ReadError, WriteError};
 use core::time::Duration;
 
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
+
 macro_rules! make_device_struct {
 	($($DefaultSerialPort:ty)?) => {
 		/// Dynamixel [`Device`] for implementing the device side of the DYNAMIXEL Protocol 2.0.
@@ -77,7 +80,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<SerialPort> Device<SerialPort, Vec<u8>>
+impl<SerialPort> Device<SerialPort, alloc::vec::Vec<u8>>
 where
 	SerialPort: crate::SerialPort,
 {
@@ -89,7 +92,7 @@ where
 	/// This will allocate a new read and write buffer of 128 bytes each.
 	/// Use [`Self::with_buffers()`] if you want to use a custom buffers.
 	pub fn new(serial_port: SerialPort) -> Result<Self, SerialPort::Error> {
-		let bus = Bus::with_buffers(serial_port, vec![0; 128], vec![0; 128])?;
+		let bus = Bus::with_buffers(serial_port, alloc::vec![0; 128], alloc::vec![0; 128])?;
 		Ok(Self { bus })
 	}
 }
@@ -145,7 +148,7 @@ where
 
 	/// Read a single [`Instruction`] with borrowed data
 	#[cfg(any(feature = "alloc", feature = "std"))]
-	pub fn read_owned(&mut self, timeout: Duration) -> Result<Instruction<Vec<u8>>, ReadError<SerialPort::Error>> {
+	pub fn read_owned(&mut self, timeout: Duration) -> Result<Instruction<alloc::vec::Vec<u8>>, ReadError<SerialPort::Error>> {
 		let packet = self.read_raw_instruction_timeout(timeout)?;
 		let packet = packet.try_into()?;
 		Ok(packet)
@@ -332,7 +335,7 @@ impl<'a> TryFrom<InstructionPacket<'a>> for Instruction<&'a [u8]> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<'a> TryFrom<InstructionPacket<'a>> for Instruction<Vec<u8>> {
+impl<'a> TryFrom<InstructionPacket<'a>> for Instruction<alloc::vec::Vec<u8>> {
 	type Error = InvalidParameterCount;
 
 	fn try_from(packet: InstructionPacket<'a>) -> Result<Self, Self::Error> {


### PR DESCRIPTION
well today I am trying to use the crate with just alloc and running into some issues as well :)

Fixed the required import paths.  
Also made the serial2 feature dependent on std as otherwise it would fail to build.

Not sure if using direct alloc imports affects std builds. It didn't seem to cause building to fail.
