### PR TITLE
use core::error::Error instead of std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/robohouse-delft/dynamixel2-rs"
 readme = "README.md"
 
 edition = "2021"
+rust-version = "1.84"
 publish = ["crates-io"]
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -288,26 +288,16 @@ impl InvalidParameterCount {
 	}
 }
 
-#[cfg(feature = "std")]
-impl<E: Debug + Display> std::error::Error for TransferError<E> {}
-#[cfg(feature = "std")]
-impl<E: Debug + Display> std::error::Error for WriteError<E> {}
-#[cfg(feature = "std")]
-impl<E: Debug + Display> std::error::Error for ReadError<E> {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidMessage {}
-#[cfg(feature = "std")]
-impl std::error::Error for MotorError {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidHeaderPrefix {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidChecksum {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidPacketId {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidInstruction {}
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidParameterCount {}
+impl<E: Debug + Display> core::error::Error for TransferError<E> {}
+impl<E: Debug + Display> core::error::Error for WriteError<E> {}
+impl<E: Debug + Display> core::error::Error for ReadError<E> {}
+impl core::error::Error for InvalidMessage {}
+impl core::error::Error for MotorError {}
+impl core::error::Error for InvalidHeaderPrefix {}
+impl core::error::Error for InvalidChecksum {}
+impl core::error::Error for InvalidPacketId {}
+impl core::error::Error for InvalidInstruction {}
+impl core::error::Error for InvalidParameterCount {}
 
 impl<E> From<WriteError<E>> for TransferError<E> {
 	fn from(other: WriteError<E>) -> Self {


### PR DESCRIPTION
Small one :) Switches the `Error` trait impls from `std::error::Error` (gated behind the `std` feature) to `core::error::Error`, so they're available in `no_std` too.

- **use `core::error::Error`, drop the `#[cfg(feature = "std")]` gating on the impls**

Only thing is `core::error::Error` was stabilised in 1.81, so this effectively sets the MSRV to that. 


Also, no rush at all, but do you think you might have some time to have a look over the project sometime this year? I've got a couple of other branches on the go:

- **async** (already open as #33) — adds async support via the [bisync crate](https://crates.io/crates/bisync). Been using it with embassy on the esp32 and it's working nicely.
- **fast_read** — adds the Fast Sync Read and Fast Bulk Read instructions. Been enjoying the speed gains from this.

No pressure on timing, just keen to hear your thoughts whenever it suits. Thanks as always! 🙂