### PR TITLE
Remove the default serial port to simplify the implementation.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,7 @@ jobs:
       - name: Build
         run: cargo build --workspace --color always --all-targets ${{ matrix.features }}
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets ${{ matrix.features }}
+        run: cargo clippy --workspace --all-targets ${{ matrix.features }}
       - name: Test
         env:
           MOCK_SERIAL_EXTRA_TIMEOUT_MS: 1000

--- a/README.md
+++ b/README.md
@@ -19,11 +19,24 @@ The main interface is the [`Client`] struct, which can be used to interact with 
 The [`Client`] struct exposes functions for all supported instructions such as [`Client::ping`], [`Client::read`], [`Client::write`] and much more.
 Additionally, you can also transmit raw commands using [`Client::write_instruction`] and [`Client::read_status_response`], or [`Client::transfer_single`].
 
+There is also an [`AsyncClient`] for use with an asynchronous serial port,
+and a [`Device`] and [`AsyncDevice`] to implement the device side of the protocol.
+
 The library currently implements all instructions except for the Control Table Backup, Fast Sync Read and Fast Sync Write instructions.
 
 ## Optional features
 
 You can enable the `log` feature to have the library use `log::trace!()` to log all sent instructions and received replies.
+
+## Example
+
+For example, to ping a motor using the synchronous client:
+```rust
+type Client = dynamixel2::Client<serial2::SerialPort>;
+let mut client = Client::open("/dev/ttyUSB0", 115200)?;
+let response = client.ping(1)?;
+println!("{response:#?}");
+```
 
 [`Client`]: https://docs.rs/dynamixel2/latest/dynamixel2/struct.Client.html
 [`Client::ping`]: https://docs.rs/dynamixel2/latest/dynamixel2/struct.Client.html#method.ping

--- a/dynamixel2-cli/src/bin/dynamixel2/main.rs
+++ b/dynamixel2-cli/src/bin/dynamixel2/main.rs
@@ -6,6 +6,8 @@ mod options;
 
 use options::{Command, MotorId, Options};
 
+type Client = dynamixel2::Client<serial2::SerialPort>;
+
 fn main() {
 	if let Err(()) = do_main(clap::Parser::parse()) {
 		std::process::exit(1);
@@ -178,8 +180,8 @@ fn do_main(options: Options) -> Result<(), ()> {
 	Ok(())
 }
 
-fn open_client(options: &Options) -> Result<dynamixel2::client::Client, ()> {
-	let client = dynamixel2::client::Client::open(&options.serial_port, options.baud_rate)
+fn open_client(options: &Options) -> Result<Client, ()> {
+	let client = Client::open(&options.serial_port, options.baud_rate)
 		.map_err(|e| log::error!("Failed to open serial port: {}: {}", options.serial_port.display(), e))?;
 	log::debug!(
 		"Using serial port {} with baud rate {}",

--- a/src/bus/bytestuff.rs
+++ b/src/bus/bytestuff.rs
@@ -86,9 +86,12 @@ pub fn stuff_inplace(buffer: &mut [u8], len: usize) -> Result<usize, BufferTooSm
 }
 
 #[cfg(test)]
+#[cfg(feature = "alloc")]
 mod test {
 	use super::*;
 	use assert2::assert;
+	use alloc::vec;
+	use alloc::vec::Vec;
 
 	fn unstuff(mut data: Vec<u8>) -> Vec<u8> {
 		let new_size = unstuff_inplace(&mut data);

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod asynch {
 	mod bus;
 	pub(crate) use bus::Bus;
 }
+
 #[path = "."]
 pub(crate) mod sync {
 	use crate::SerialPort;
@@ -257,16 +258,23 @@ mod test {
 
 	#[test]
 	fn test_buffer_too_small() {
+		use crate::SerialPort;
+
 		let read_buffer = crate::static_buffer!(128);
 		let write_buffer = crate::static_buffer!(128);
 
 		// Dummy serial port used to feed packages
 		// It does not support writing them etc.
-		struct DummySerial {}
+		struct DummySerial;
+
+		#[derive(Debug)]
+		struct Error;
+		#[derive(Debug, Copy, Clone)]
+		struct Instant;
 
 		impl crate::SerialPort for DummySerial {
-			type Error = std::io::Error;
-			type Instant = std::time::Instant;
+			type Error = Error;
+			type Instant = Instant;
 
 			fn baud_rate(&self) -> Result<u32, Self::Error> {
 				Ok(115_200)
@@ -306,7 +314,7 @@ mod test {
 			}
 
 			fn make_deadline(&self, _timeout: core::time::Duration) -> Self::Instant {
-				std::time::Instant::now() + _timeout
+				Instant
 			}
 
 			fn is_timeout_error(_error: &Self::Error) -> bool {
@@ -315,10 +323,10 @@ mod test {
 		}
 
 		// Setup the bus with a dummy serial interface
-		let mut bus = sync::Bus::with_buffers(DummySerial {}, read_buffer, write_buffer).unwrap();
+		let mut bus = sync::Bus::with_buffers(DummySerial, read_buffer, write_buffer).unwrap();
 
 		// Read the corrupt package
-		let deadline = std::time::Instant::now() + Duration::from_secs(1);
+		let deadline = bus.serial_port.make_deadline(Duration::from_secs(1));
 		let result = bus.read_packet_deadline(deadline);
 		assert!(matches!(result.unwrap_err(), crate::ReadError::BufferFull(_)));
 

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -90,8 +90,8 @@ pub type DefaultBuffer = &'static mut [u8];
 /// The macro is usable as expression in const context.
 ///
 /// # Usage:
-#[cfg_attr(feature = "serial2", doc = "```no_run")]
-#[cfg_attr(not(feature = "serial2"), doc = "```ignore")]
+/// ```no_run
+/// # #[cfg(feature = "serial2")]
 /// # fn main() -> Result<(), std::io::Error> {
 /// # let serial_port = serial2::SerialPort::open("/dev/null", 57600)?;
 /// use dynamixel2::{Client, static_buffer};

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -13,46 +13,28 @@ use super::SerialPort;
 /// The official SDK adds a flat 34 milliseconds, so we mimic that.
 const DEFAULT_RESPONSE_TIMEOUT_PADDING: Duration = Duration::from_millis(34);
 
-macro_rules! make_client_struct {
-	($($DefaultSerialPort:ty)?) => {
-		/// Client for the Dynamixel Protocol 2 communication.
-		///
-		/// Used to interact with devices on the bus.
-		///
-		/// If a serial port backend is enabled, the `Port` generic type argument defaults to that backend's
-		/// serial port type: `serial2::SerialPort` with the `"serial2"` feature, or `serial2_tokio::SerialPort`
-		/// (for the asynchronous client) with the `"serial2-tokio"` feature.
-		/// If neither is enabled, the `Port` argument must always be specified.
-		///
-		/// The `Buffer` generic type argument defaults to `Vec<u8>` if the `"alloc"` feature is enabled,
-		/// and to `&'static mut [u8]` otherwise.
-		/// See the [`crate::static_buffer!()`] macro for a way to safely create a mutable static buffer.
-		pub struct Client<Port $(= $DefaultSerialPort)?, Buffer = crate::bus::DefaultBuffer>
-		where
-			Port: SerialPort,
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			bus: Bus<Port, Buffer>,
+/// Client for the Dynamixel Protocol 2 communication.
+///
+/// Used to interact with devices on the bus.
+///
+/// If a serial port backend is enabled, the `Port` generic type argument defaults to that backend's
+/// serial port type: `serial2::SerialPort` with the `"serial2"` feature, or `serial2_tokio::SerialPort`
+/// (for the asynchronous client) with the `"serial2-tokio"` feature.
+/// If neither is enabled, the `Port` argument must always be specified.
+///
+/// The `Buffer` generic type argument defaults to `Vec<u8>` if the `"alloc"` feature is enabled,
+/// and to `&'static mut [u8]` otherwise.
+/// See the [`crate::static_buffer!()`] macro for a way to safely create a mutable static buffer.
+pub struct Client<Port, Buffer = crate::bus::DefaultBuffer>
+where
+	Port: SerialPort,
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	bus: Bus<Port, Buffer>,
 
-			/// Additional time added to the automatically calculated read timeout of a status response.
-			response_timeout_padding: Duration,
-		}
-	};
+	/// Additional time added to the automatically calculated read timeout of a status response.
+	response_timeout_padding: Duration,
 }
-
-#[cfg(feature = "serial2")]
-#[super::only_sync]
-make_client_struct!(super::Serial2Port);
-#[cfg(not(feature = "serial2"))]
-#[super::only_sync]
-make_client_struct!();
-
-#[cfg(feature = "serial2-tokio")]
-#[super::only_async]
-make_client_struct!(super::Serial2Port);
-#[cfg(not(feature = "serial2-tokio"))]
-#[super::only_async]
-make_client_struct!();
 
 impl<Port, Buffer> core::fmt::Debug for Client<Port, Buffer>
 where
@@ -67,57 +49,87 @@ where
 	}
 }
 
-// Only invoked for whichever of the sync/async variants has its serial port backend enabled,
-// so it is legitimately unused in the other variant's compilation.
-#[allow(unused_macros)]
-macro_rules! make_serial2_client_impls {
-	($DefaultSerialPort:ty) => {
-		impl Client<$DefaultSerialPort, Vec<u8>> {
-			/// Open a serial port with the given baud rate.
-			///
-			/// This will allocate a new read and write buffer of 128 bytes each.
-			/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
-			pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
-				let serial_port = <$DefaultSerialPort>::open(path, baud_rate)?;
-				let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
-				Ok(Self {
-					bus,
-					response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
-				})
-			}
-		}
-
-		impl<Buffer> Client<$DefaultSerialPort, Buffer>
-		where
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			/// Open a serial port with the given baud rate.
-			///
-			/// This will allocate a new read and write buffer of 128 bytes each.
-			pub fn open_with_buffers(
-				path: impl AsRef<std::path::Path>,
-				baud_rate: u32,
-				read_buffer: Buffer,
-				write_buffer: Buffer,
-			) -> std::io::Result<Self> {
-				let serial_port = <$DefaultSerialPort>::open(path, baud_rate)?;
-				let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
-				Ok(Self {
-					bus,
-					response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
-				})
-			}
-		}
-	};
+#[cfg(feature = "serial2")]
+#[super::only_sync]
+impl Client<serial2::SerialPort, Vec<u8>> {
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
+	pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
+		let serial_port = serial2::SerialPort::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
+		Ok(Self {
+			bus,
+			response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
+		})
+	}
 }
 
 #[cfg(feature = "serial2")]
 #[super::only_sync]
-make_serial2_client_impls!(super::Serial2Port);
+impl<Buffer> Client<serial2::SerialPort, Buffer>
+where
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	pub fn open_with_buffers(
+		path: impl AsRef<std::path::Path>,
+		baud_rate: u32,
+		read_buffer: Buffer,
+		write_buffer: Buffer,
+	) -> std::io::Result<Self> {
+		let serial_port = serial2::SerialPort::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
+		Ok(Self {
+			bus,
+			response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
+		})
+	}
+}
 
 #[cfg(feature = "serial2-tokio")]
 #[super::only_async]
-make_serial2_client_impls!(super::Serial2Port);
+impl Client<serial2_tokio::SerialPort, Vec<u8>> {
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
+	pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
+		let serial_port = serial2_tokio::SerialPort::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
+		Ok(Self {
+			bus,
+			response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
+		})
+	}
+}
+
+#[cfg(feature = "serial2-tokio")]
+#[super::only_async]
+impl<Buffer> Client<serial2_tokio::SerialPort, Buffer>
+where
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	pub fn open_with_buffers(
+		path: impl AsRef<std::path::Path>,
+		baud_rate: u32,
+		read_buffer: Buffer,
+		write_buffer: Buffer,
+	) -> std::io::Result<Self> {
+		let serial_port = serial2_tokio::SerialPort::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
+		Ok(Self {
+			bus,
+			response_timeout_padding: DEFAULT_RESPONSE_TIMEOUT_PADDING,
+		})
+	}
+}
 
 #[cfg(feature = "alloc")]
 impl<Port> Client<Port, alloc::vec::Vec<u8>>

--- a/src/client/instructions/bulk_write.rs
+++ b/src/client/instructions/bulk_write.rs
@@ -25,8 +25,8 @@ where
 	/// This function also panics if the data length for a motor exceeds the capacity of a `u16`.
 	///
 	/// # Example
-	#[cfg_attr(feature = "serial2", doc = "```no_run")]
-	#[cfg_attr(not(feature = "serial2"), doc = "```ignore")]
+	/// ```no_run
+	/// # #[cfg(feature = "serial2")]
 	/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 	/// use dynamixel2::client::BulkWriteData;
 	/// use std::time::Duration;

--- a/src/client/instructions/mod.rs
+++ b/src/client/instructions/mod.rs
@@ -1,5 +1,5 @@
 //! Types and functions for specific instructions.
-use super::{bisync, client::Client, only_async, only_sync, SerialPort};
+use super::{bisync, client::Client, only_sync, SerialPort};
 
 mod action;
 pub(crate) mod bulk_read;

--- a/src/client/instructions/ping.rs
+++ b/src/client/instructions/ping.rs
@@ -29,38 +29,21 @@ where
 	}
 }
 
-macro_rules! make_scan_struct {
-	($($DefaultSerialPort:ty)?) => {
-		/// A scan operation that yields a [`Response`] for each motor that replies to the broadcast ping.
-		///
-		/// Scanning ends when no further reply arrives within the timeout. The replies must be fully consumed
-		/// before the client is used again. The synchronous client is an [`Iterator`] and drains any unread
-		/// replies on drop; the asynchronous client cannot (a [`Drop`] can't `.await`), so call
-		/// [`scan_next`](Self::scan_next) until it returns [`None`] — dropping it early corrupts the next
-		/// transaction.
-		pub struct Scan<'a, Port $(= $DefaultSerialPort)?, Buffer = crate::bus::DefaultBuffer>
-		where
-			Port: SerialPort,
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			client: &'a mut Client<Port, Buffer>,
-		}
-	}
+/// A scan operation that yields a [`Response`] for each motor that replies to the broadcast ping.
+///
+/// Scanning ends when no further reply arrives within the timeout. The replies must be fully consumed
+/// before the client is used again. The synchronous client is an [`Iterator`] and drains any unread
+/// replies on drop; the asynchronous client cannot (a [`Drop`] can't `.await`), so call
+/// [`scan_next`](Self::scan_next) until it returns [`None`] — dropping it early corrupts the next
+/// transaction.
+#[super::bisync]
+pub struct Scan<'a, Port, Buffer = crate::bus::DefaultBuffer>
+where
+	Port: SerialPort,
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	client: &'a mut Client<Port, Buffer>,
 }
-
-#[cfg(feature = "serial2")]
-#[super::only_sync]
-make_scan_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2"))]
-#[super::only_sync]
-make_scan_struct!();
-
-#[cfg(feature = "serial2-tokio")]
-#[super::only_async]
-make_scan_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2-tokio"))]
-#[super::only_async]
-make_scan_struct!();
 
 impl<Port, Buffer> core::fmt::Debug for Scan<'_, Port, Buffer>
 where

--- a/src/client/instructions/sync_read.rs
+++ b/src/client/instructions/sync_read.rs
@@ -98,78 +98,44 @@ where
 	}
 }
 
-macro_rules! make_sync_read_bytes_struct {
-	($($DefaultSerialPort:ty)?) => {
-		/// A sync read operation that returns the unparsed bytes from each motor, one reply at a time.
-		///
-		/// The replies must be fully consumed before the client is used again. The synchronous client is an
-		/// [`Iterator`] and drains any unread replies on drop; the asynchronous client cannot (a [`Drop`] can't
-		/// `.await`), so call [`read_next`](Self::read_next) until it returns [`None`] — dropping it early
-		/// corrupts the next transaction.
-		pub struct SyncReadBytes<'a, T, Port $(= $DefaultSerialPort)?, Buffer = crate::bus::DefaultBuffer>
-		where
-			T: ?Sized,
-			Port: SerialPort,
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			client: &'a mut Client<Port, Buffer>,
-			count: u16,
-			motor_ids: &'a [u8],
-			index: usize,
-			data: PhantomData<fn() -> T>,
-		}
-	}
+/// A sync read operation that returns the unparsed bytes from each motor, one reply at a time.
+///
+/// The replies must be fully consumed before the client is used again. The synchronous client is an
+/// [`Iterator`] and drains any unread replies on drop; the asynchronous client cannot (a [`Drop`] can't
+/// `.await`), so call [`read_next`](Self::read_next) until it returns [`None`] — dropping it early
+/// corrupts the next transaction.
+#[super::bisync]
+pub struct SyncReadBytes<'a, T, Port, Buffer = crate::bus::DefaultBuffer>
+where
+	T: ?Sized,
+	Port: SerialPort,
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	client: &'a mut Client<Port, Buffer>,
+	count: u16,
+	motor_ids: &'a [u8],
+	index: usize,
+	data: PhantomData<fn() -> T>,
 }
 
-#[cfg(feature = "serial2")]
-#[super::only_sync]
-make_sync_read_bytes_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2"))]
-#[super::only_sync]
-make_sync_read_bytes_struct!();
-
-#[cfg(feature = "serial2-tokio")]
-#[super::only_async]
-make_sync_read_bytes_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2-tokio"))]
-#[super::only_async]
-make_sync_read_bytes_struct!();
-
-macro_rules! make_sync_read_struct {
-	($($DefaultSerialPort:ty)?) => {
-		/// A sync read operation that returns the parsed value from each motor, one reply at a time.
-		///
-		/// The replies must be fully consumed before the client is used again. The synchronous client is an
-		/// [`Iterator`] and drains any unread replies on drop; the asynchronous client cannot (a [`Drop`] can't
-		/// `.await`), so call [`read_next`](Self::read_next) until it returns [`None`] — dropping it early
-		/// corrupts the next transaction.
-		pub struct SyncRead<'a, T, Port $(= $DefaultSerialPort)?, Buffer = crate::bus::DefaultBuffer>
-		where
-			T: Data,
-			Port: SerialPort,
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			client: &'a mut Client<Port, Buffer>,
-			motor_ids: &'a [u8],
-			index: usize,
-			data: PhantomData<fn() -> T>,
-		}
-	}
+/// A sync read operation that returns the parsed value from each motor, one reply at a time.
+///
+/// The replies must be fully consumed before the client is used again. The synchronous client is an
+/// [`Iterator`] and drains any unread replies on drop; the asynchronous client cannot (a [`Drop`] can't
+/// `.await`), so call [`read_next`](Self::read_next) until it returns [`None`] — dropping it early
+/// corrupts the next transaction.
+#[super::bisync]
+pub struct SyncRead<'a, T, Port, Buffer = crate::bus::DefaultBuffer>
+where
+	T: Data,
+	Port: SerialPort,
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	client: &'a mut Client<Port, Buffer>,
+	motor_ids: &'a [u8],
+	index: usize,
+	data: PhantomData<fn() -> T>,
 }
-
-#[cfg(feature = "serial2")]
-#[super::only_sync]
-make_sync_read_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2"))]
-#[super::only_sync]
-make_sync_read_struct!();
-
-#[cfg(feature = "serial2-tokio")]
-#[super::only_async]
-make_sync_read_struct!(super::super::Serial2Port);
-#[cfg(not(feature = "serial2-tokio"))]
-#[super::only_async]
-make_sync_read_struct!();
 
 impl<T, Port, Buffer> core::fmt::Debug for SyncReadBytes<'_, T, Port, Buffer>
 where

--- a/src/client/instructions/sync_write.rs
+++ b/src/client/instructions/sync_write.rs
@@ -20,8 +20,8 @@ where
 	/// This function panics if that is not the case.
 	///
 	/// # Example
-	#[cfg_attr(feature = "serial2", doc = "```no_run")]
-	#[cfg_attr(not(feature = "serial2"), doc = "```ignore")]
+	/// ```no_run
+	/// # #[cfg(feature = "serial2")]
 	/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 	/// use dynamixel2::Client;
 	/// use dynamixel2::client::SyncWriteData;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,20 +7,17 @@ pub(crate) mod asynch {
 	use crate::bus::asynch::Bus;
 	use crate::AsyncSerialPort as SerialPort;
 	use bisync::asynchronous::*;
-	#[cfg(feature = "serial2-tokio")]
-	use serial2_tokio::SerialPort as Serial2Port;
 
 	mod client;
 	pub use client::Client;
 	pub(crate) mod instructions;
 }
+
 #[path = "."]
 pub(crate) mod sync {
 	use crate::bus::sync::Bus;
 	use crate::SerialPort;
 	use bisync::synchronous::*;
-	#[cfg(feature = "serial2")]
-	use serial2::SerialPort as Serial2Port;
 
 	mod client;
 	pub use client::Client;

--- a/src/device/device.rs
+++ b/src/device/device.rs
@@ -4,41 +4,23 @@ use crate::device::Instruction;
 use crate::{ReadError, WriteError};
 use core::time::Duration;
 
-macro_rules! make_device_struct {
-	($($DefaultSerialPort:ty)?) => {
-		/// Dynamixel [`Device`] for implementing the device side of the DYNAMIXEL Protocol 2.0.
-		///
-		/// If a serial port backend is enabled, the `Port` generic type argument defaults to that backend's
-		/// serial port type: `serial2::SerialPort` with the `"serial2"` feature, or `serial2_tokio::SerialPort`
-		/// (for the asynchronous device) with the `"serial2-tokio"` feature.
-		/// If neither is enabled, the `Port` argument must always be specified.
-		///
-		/// The `Buffer` generic type argument defaults to `Vec<u8>` if the `"alloc"` feature is enabled,
-		/// and to `&'static mut [u8]` otherwise.
-		/// See the [`crate::static_buffer!()`] macro for a way to safely create a mutable static buffer.
-		pub struct Device<Port $(= $DefaultSerialPort)?, Buffer = crate::bus::DefaultBuffer>
-		where
-			Port: SerialPort,
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			bus: Bus<Port, Buffer>,
-		}
-	};
+/// Dynamixel [`Device`] for implementing the device side of the DYNAMIXEL Protocol 2.0.
+///
+/// If a serial port backend is enabled, the `Port` generic type argument defaults to that backend's
+/// serial port type: `serial2::SerialPort` with the `"serial2"` feature, or `serial2_tokio::SerialPort`
+/// (for the asynchronous device) with the `"serial2-tokio"` feature.
+/// If neither is enabled, the `Port` argument must always be specified.
+///
+/// The `Buffer` generic type argument defaults to `Vec<u8>` if the `"alloc"` feature is enabled,
+/// and to `&'static mut [u8]` otherwise.
+/// See the [`crate::static_buffer!()`] macro for a way to safely create a mutable static buffer.
+pub struct Device<Port, Buffer = crate::bus::DefaultBuffer>
+where
+	Port: SerialPort,
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	bus: Bus<Port, Buffer>,
 }
-
-#[cfg(feature = "serial2")]
-#[super::only_sync]
-make_device_struct!(super::Serial2Port);
-#[cfg(not(feature = "serial2"))]
-#[super::only_sync]
-make_device_struct!();
-
-#[cfg(feature = "serial2-tokio")]
-#[super::only_async]
-make_device_struct!(super::Serial2Port);
-#[cfg(not(feature = "serial2-tokio"))]
-#[super::only_async]
-make_device_struct!();
 
 impl<Port, Buffer> core::fmt::Debug for Device<Port, Buffer>
 where
@@ -53,51 +35,76 @@ where
 	}
 }
 
-// Only invoked for whichever of the sync/async variants has its serial port backend enabled,
-// so it is legitimately unused in the other variant's compilation.
-#[allow(unused_macros)]
-macro_rules! make_serial2_device_impls {
-	($DefaultSerialPort:ty) => {
-		impl Device<$DefaultSerialPort, Vec<u8>> {
-			/// Open a serial port with the given baud rate.
-			///
-			/// This will allocate a new read and write buffer of 128 bytes each.
-			/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
-			pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
-				let serial_port = <$DefaultSerialPort>::open(path, baud_rate)?;
-				let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
-				Ok(Self { bus })
-			}
-		}
-
-		impl<Buffer> Device<$DefaultSerialPort, Buffer>
-		where
-			Buffer: AsRef<[u8]> + AsMut<[u8]>,
-		{
-			/// Open a serial port with the given baud rate.
-			///
-			/// This will allocate a new read and write buffer of 128 bytes each.
-			pub fn open_with_buffers(
-				path: impl AsRef<std::path::Path>,
-				baud_rate: u32,
-				read_buffer: Buffer,
-				write_buffer: Buffer,
-			) -> std::io::Result<Self> {
-				let serial_port = <$DefaultSerialPort>::open(path, baud_rate)?;
-				let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
-				Ok(Self { bus })
-			}
-		}
-	};
+#[cfg(feature = "serial2")]
+#[super::only_sync]
+impl Device<serial2::SerialPort, Vec<u8>> {
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
+	pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
+		let serial_port = <serial2::SerialPort>::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
+		Ok(Self { bus })
+	}
 }
 
 #[cfg(feature = "serial2")]
 #[super::only_sync]
-make_serial2_device_impls!(super::Serial2Port);
+impl<Buffer> Device<serial2::SerialPort, Buffer>
+where
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	pub fn open_with_buffers(
+		path: impl AsRef<std::path::Path>,
+		baud_rate: u32,
+		read_buffer: Buffer,
+		write_buffer: Buffer,
+	) -> std::io::Result<Self> {
+		let serial_port = <serial2::SerialPort>::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
+		Ok(Self { bus })
+	}
+}
 
 #[cfg(feature = "serial2-tokio")]
 #[super::only_async]
-make_serial2_device_impls!(super::Serial2Port);
+impl Device<serial2_tokio::SerialPort, Vec<u8>> {
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	/// Use [`Self::open_with_buffers()`] if you want to use a custom buffers.
+	pub fn open(path: impl AsRef<std::path::Path>, baud_rate: u32) -> std::io::Result<Self> {
+		let serial_port = <serial2_tokio::SerialPort>::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, vec![0; 128], vec![0; 128], baud_rate);
+		Ok(Self { bus })
+	}
+}
+
+#[cfg(feature = "serial2-tokio")]
+#[super::only_async]
+impl<Buffer> Device<serial2_tokio::SerialPort, Buffer>
+where
+	Buffer: AsRef<[u8]> + AsMut<[u8]>,
+{
+	/// Open a serial port with the given baud rate.
+	///
+	/// This will allocate a new read and write buffer of 128 bytes each.
+	pub fn open_with_buffers(
+		path: impl AsRef<std::path::Path>,
+		baud_rate: u32,
+		read_buffer: Buffer,
+		write_buffer: Buffer,
+	) -> std::io::Result<Self> {
+		let serial_port = <serial2_tokio::SerialPort>::open(path, baud_rate)?;
+		let bus = Bus::with_buffers_and_baud_rate(serial_port, read_buffer, write_buffer, baud_rate);
+		Ok(Self { bus })
+	}
+}
+
 
 #[cfg(feature = "alloc")]
 impl<Port> Device<Port, alloc::vec::Vec<u8>>

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -12,8 +12,6 @@ pub(crate) mod asynch {
 	use crate::bus::asynch::Bus;
 	use crate::AsyncSerialPort as SerialPort;
 	use bisync::asynchronous::*;
-	#[cfg(feature = "serial2-tokio")]
-	use serial2_tokio::SerialPort as Serial2Port;
 
 	pub(super) mod device;
 }
@@ -22,8 +20,6 @@ pub(super) mod sync {
 	use crate::bus::sync::Bus;
 	use crate::SerialPort;
 	use bisync::synchronous::*;
-	#[cfg(feature = "serial2")]
-	use serial2::SerialPort as Serial2Port;
 
 	pub(super) mod device;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -508,7 +508,7 @@ impl Display for InvalidMessage {
 
 impl Display for MotorError {
 	fn fmt(&self, f: &mut Formatter) -> FmtResult {
-		write!(f, "motor reported error status: {:#02X}", self.raw,)
+		write!(f, "motor reported error status: 0x{:02X}", self.raw,)
 	}
 }
 
@@ -526,7 +526,7 @@ impl Display for InvalidChecksum {
 	fn fmt(&self, f: &mut Formatter) -> FmtResult {
 		write!(
 			f,
-			"invalid checksum, message claims {:#02X}, computed {:#02X}",
+			"invalid checksum, message claims 0x{:02X}, computed 0x{:02X}",
 			self.message, self.computed
 		)
 	}
@@ -535,9 +535,9 @@ impl Display for InvalidChecksum {
 impl Display for InvalidPacketId {
 	fn fmt(&self, f: &mut Formatter) -> FmtResult {
 		if let Some(expected) = self.expected {
-			write!(f, "invalid packet ID, expected {:#02X}, got {:#02X}", expected, self.actual)
+			write!(f, "invalid packet ID, expected 0x{:02X}, got 0x{:02X}", expected, self.actual)
 		} else {
-			write!(f, "invalid packet ID: {:#02X}", self.actual)
+			write!(f, "invalid packet ID: 0x{:02X}", self.actual)
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,27 @@
 //! The [`Client`] struct exposes functions for all supported instructions such as [`Client::ping`], [`Client::read`], [`Client::write`] and much more.
 //! Additionally, you can also transmit raw commands using [`Client::write_instruction`] and [`Client::read_status_response`], or [`Client::transfer_single`].
 //!
+//! There is also an [`AsyncClient`] for use with an asynchronous serial port,
+//! and a [`Device`] and [`AsyncDevice`] to implement the device side of the protocol.
+//!
 //! The library currently implements all instructions except for the Control Table Backup, Fast Sync Read and Fast Sync Write instructions.
 //!
 //! # Optional features
 //!
 //! You can enable the `log` feature to have the library use `log::trace!()` to log all sent instructions and received replies.
 //!
+//! # Example
+//!
+//! For example, to ping a motor using the synchronous client:
+//! ```no_run
+//! # fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+//! type Client = dynamixel2::Client<serial2::SerialPort>;
+//! let mut client = Client::open("/dev/ttyUSB0", 115200)?;
+//! let response = client.ping(1)?;
+//! println!("{response:#?}");
+//! # Ok(())
+//! # }
+//! ```
 
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //!
 //! For example, to ping a motor using the synchronous client:
 //! ```no_run
+//! # #[cfg(feature = "serial2")]
 //! # fn do_main() -> Result<(), Box<dyn std::error::Error>> {
 //! type Client = dynamixel2::Client<serial2::SerialPort>;
 //! let mut client = Client::open("/dev/ttyUSB0", 115200)?;

--- a/tests/common/mock/mod.rs
+++ b/tests/common/mock/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use dynamixel2::{client::Client, device::Device};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 pub mod mock;
 // The real-hardware harness uses the synchronous `serial2` backend directly.
 #[cfg(feature = "serial2")]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use assert2::{assert, let_assert};
 use dynamixel2::client::{BulkReadData, SyncWriteData};
 use test_log::test;


### PR DESCRIPTION
This PR removes the default serial port type and the Serial2Port type alias.

We've long since broken backwards compatibility with the last release, and I think in the end, providing a default serial port type is no longer worth it. I also prefer people write `serial2::SerialPort` than `dynamixel2::Serial2Port`.

Instead, I added an example to the library documentation to incept the idea of making a local type alias with the desired serial port type.

@omelia-iliffe : Can you review this? :)